### PR TITLE
FIX:molecule fastsync timeout

### DIFF
--- a/controls/roles/fastsync/tasks/main.yml
+++ b/controls/roles/fastsync/tasks/main.yml
@@ -3,7 +3,8 @@
   get_url:
     url: "https://fastsync.stereum.cloud/{{ stereum.fastsync.network }}/{{ stereum.fastsync.service }}/{{ stereum.fastsync.service }}-latest.tar.gz"
     dest: "/tmp/{{ stereum.fastsync.service }}-latest.tar.gz"
-    mode: '0644'
+    mode: '0600'
+    timeout: 60
   become: yes
 
 - name: Set directory permissions for destination

--- a/controls/roles/fastsync/tasks/main.yml
+++ b/controls/roles/fastsync/tasks/main.yml
@@ -3,7 +3,7 @@
   get_url:
     url: "https://fastsync.stereum.cloud/{{ stereum.fastsync.network }}/{{ stereum.fastsync.service }}/{{ stereum.fastsync.service }}-latest.tar.gz"
     dest: "/tmp/{{ stereum.fastsync.service }}-latest.tar.gz"
-    mode: '0600'
+    mode: 0600
     timeout: 60
   become: yes
 


### PR DESCRIPTION
Attempt to fix the following issue with molecule tests:
```
  TASK [fastsync : Download latest blockchain snapshots] *************************
  An exception occurred during task execution. To see the full traceback, use -vvv. The error was: socket.timeout: The read operation timed out
  fatal: [manage-service--ssv-nimbus--ubuntu-20.04]: FAILED! => {"changed": false, "elapsed": 0, "msg": "failed to create temporary content file: The read operation timed out"}
  changed: [manage-service--ssv-nimbus--centos-stream-8]
```

https://github.com/stereum-dev/ethereum-node/runs/5036655609?check_suite_focus=true#step:7:279