### PR TITLE
FIX:centos lacks zip pkgs in some versions

### DIFF
--- a/controls/roles/setup/tasks/main.yml
+++ b/controls/roles/setup/tasks/main.yml
@@ -13,6 +13,8 @@
 
 - include_tasks: docker.yml
 
+- include_tasks: zip-centos.yml
+
 - include_tasks: add-stereum-user.yml
 
 - include_tasks: stereum-config.yml

--- a/controls/roles/setup/tasks/zip-centos.yml
+++ b/controls/roles/setup/tasks/zip-centos.yml
@@ -1,0 +1,9 @@
+---
+- name: Install system packages for zip
+  yum:
+    name:
+      - zip
+      - unzip
+    state: present
+
+# EOF


### PR DESCRIPTION
Issue:
```
  TASK [fastsync : Deflate blockchain snapshot archives] *************************
  fatal: [fastsync--default--centos-stream-8]: FAILED! => {"changed": false, "msg": "Failed to find handler for \"/tmp/lighthouse-latest.tar.gz\". Make sure the required command to extract the file is installed. Unable to find required 'unzip' or 'zipinfo' binary in the path. Command \"/usr/bin/gtar\" could not handle archive."}
```
https://github.com/stereum-dev/ethereum-node/runs/5048410396?check_suite_focus=true#step:7:271