### PR TITLE
FIX:molecule ssv check ports after services boot

### DIFF
--- a/controls/roles/manage-service/molecule/ssv-lighthouse/verify.yml
+++ b/controls/roles/manage-service/molecule/ssv-lighthouse/verify.yml
@@ -7,18 +7,6 @@
     register: stereum_services_dir
   - debug:
       msg: "{{ stereum_services_dir }}"
-  # container's images & ports
-  - shell: docker ps
-    register: stereum_docker_ps
-  - debug:
-      msg: "{{ stereum_docker_ps }}"
-  - assert:
-      that:
-      - stereum_docker_ps.stdout.find("stereum/lighthouse") != -1
-      - stereum_docker_ps.stdout.find("bloxstaking/ssv-node") != -1
-      - stereum_docker_ps.stdout.find("9000->9000") != -1
-      - stereum_docker_ps.stdout.find("12000->12000") != -1
-      - stereum_docker_ps.stdout.find("13000->13000") != -1
   # ufw
   - shell: ufw status
     register: stereum_ufw_status
@@ -39,7 +27,7 @@
     assert:
       that:
         - ssv_config_file.stat.exists
-  - name: Waiting for the services to up
+  - name: Waiting for the services to start properly
     pause:
       minutes: 10
   # lh beacon & ssv logs
@@ -55,3 +43,17 @@
     until: blox_ssv.stdout.find("beacon node is not healthy") == -1
     retries: 360
     delay: 10
+  # container's images & ports
+  - shell: docker ps
+    register: stereum_docker_ps
+  - debug:
+      msg: "{{ stereum_docker_ps }}"
+  - assert:
+      that:
+      - stereum_docker_ps.stdout.find("stereum/lighthouse") != -1
+      - stereum_docker_ps.stdout.find("bloxstaking/ssv-node") != -1
+      - stereum_docker_ps.stdout.find("9000->9000") != -1
+      - stereum_docker_ps.stdout.find("12000->12000") != -1
+      - stereum_docker_ps.stdout.find("13000->13000") != -1
+
+# EOF

--- a/controls/roles/manage-service/molecule/ssv-nimbus/verify.yml
+++ b/controls/roles/manage-service/molecule/ssv-nimbus/verify.yml
@@ -7,19 +7,6 @@
     register: stereum_services_dir
   - debug:
       msg: "{{ stereum_services_dir }}"
-  # container's images & ports
-  - shell: docker ps
-    register: stereum_docker_ps
-  - debug:
-      msg: "{{ stereum_docker_ps }}"
-  - assert:
-      that:
-      - stereum_docker_ps.stdout.find("stereum/nimbus") != -1
-      - stereum_docker_ps.stdout.find("bloxstaking/ssv-node") != -1
-      - stereum_docker_ps.stdout.find("9000->9000") != -1
-      - stereum_docker_ps.stdout.find("9190->9190") != -1
-      - stereum_docker_ps.stdout.find("12000->12000") != -1
-      - stereum_docker_ps.stdout.find("13000->13000") != -1
   # ufw
   - shell: ufw status
     register: stereum_ufw_status
@@ -40,7 +27,7 @@
     assert:
       that:
         - ssv_config_file.stat.exists
-  - name: Waiting for the services to up
+  - name: Waiting for the services to start properly
     pause:
       minutes: 10
   # nimbus beacon & ssv logs
@@ -56,3 +43,18 @@
     until: blox_ssv.stdout.find("beacon node is not healthy") == -1
     retries: 360
     delay: 10
+  # container's images & ports
+  - shell: docker ps
+    register: stereum_docker_ps
+  - debug:
+      msg: "{{ stereum_docker_ps }}"
+  - assert:
+      that:
+      - stereum_docker_ps.stdout.find("stereum/nimbus") != -1
+      - stereum_docker_ps.stdout.find("bloxstaking/ssv-node") != -1
+      - stereum_docker_ps.stdout.find("9000->9000") != -1
+      - stereum_docker_ps.stdout.find("9190->9190") != -1
+      - stereum_docker_ps.stdout.find("12000->12000") != -1
+      - stereum_docker_ps.stdout.find("13000->13000") != -1
+
+# EOF

--- a/controls/roles/manage-service/molecule/ssv-teku/verify.yml
+++ b/controls/roles/manage-service/molecule/ssv-teku/verify.yml
@@ -7,19 +7,6 @@
     register: stereum_services_dir
   - debug:
       msg: "{{ stereum_services_dir }}"
-  # container's images & ports
-  - shell: docker ps
-    register: stereum_docker_ps
-  - debug:
-      msg: "{{ stereum_docker_ps }}"
-  - assert:
-      that:
-      - stereum_docker_ps.stdout.find("consensys/teku") != -1
-      - stereum_docker_ps.stdout.find("bloxstaking/ssv-node") != -1
-      - stereum_docker_ps.stdout.find("5051") != -1
-      - stereum_docker_ps.stdout.find("9001->9001") != -1
-      - stereum_docker_ps.stdout.find("12000->12000") != -1
-      - stereum_docker_ps.stdout.find("13000->13000") != -1
   # ufw
   - shell: ufw status
     register: stereum_ufw_status
@@ -40,7 +27,7 @@
     assert:
       that:
         - ssv_config_file.stat.exists
-  - name: Waiting for the services to up
+  - name: Waiting for the services to start properly
     pause:
       minutes: 10
   # teku beacon & ssv logs
@@ -56,3 +43,18 @@
     until: blox_ssv.stdout.find("beacon node is not healthy") == -1
     retries: 360
     delay: 10
+  # container's images & ports
+  - shell: docker ps
+    register: stereum_docker_ps
+  - debug:
+      msg: "{{ stereum_docker_ps }}"
+  - assert:
+      that:
+      - stereum_docker_ps.stdout.find("consensys/teku") != -1
+      - stereum_docker_ps.stdout.find("bloxstaking/ssv-node") != -1
+      - stereum_docker_ps.stdout.find("5051") != -1
+      - stereum_docker_ps.stdout.find("9001->9001") != -1
+      - stereum_docker_ps.stdout.find("12000->12000") != -1
+      - stereum_docker_ps.stdout.find("13000->13000") != -1
+
+# EOF


### PR DESCRIPTION
Issue:
```
  TASK [debug] *******************************************************************
  ok: [manage-service--ssv-teku--centos-stream-8] => {
      "msg": {
          "changed": true,
          "cmd": "docker ps",
          "delta": "0:00:00.058989",
          "end": "2022-02-02 17:41:09.936993",
          "failed": false,
          "msg": "",
          "rc": 0,
          "start": "2022-02-02 17:41:09.878004",
          "stderr": "",
          "stderr_lines": [],
          "stdout": "CONTAINER ID   IMAGE                                COMMAND                  CREATED          STATUS                        PORTS                                                                                    NAMES\n053c6ad076b2   bloxstaking/ssv-node:latest-ubuntu   \"bash -c 'touch /dat…\"   10 seconds ago   Restarting (2) 1 second ago                                                                                            stereum-f6a89270-7fa4-11ec-9378-fbd364d02350\n6cdd4e647ce0   consensys/teku:21.12.2               \"/opt/teku/bin/teku …\"   50 seconds ago   Up 49 seconds                 5051/tcp, 8008/tcp, 9000/tcp, 9000/udp, 0.0.0.0:9001->9001/tcp, 0.0.0.0:9001->9001/udp   stereum-731c4b72-7f7c-11ec-b824-c304f53cda24",
          "stdout_lines": [
              "CONTAINER ID   IMAGE                                COMMAND                  CREATED          STATUS                        PORTS                                                                                    NAMES",
              "053c6ad076b2   bloxstaking/ssv-node:latest-ubuntu   \"bash -c 'touch /dat…\"   10 seconds ago   Restarting (2) 1 second ago                                                                                            stereum-f6a89270-7fa4-11ec-9378-fbd364d02350",
              "6cdd4e647ce0   consensys/teku:21.12.2               \"/opt/teku/bin/teku …\"   50 seconds ago   Up 49 seconds                 5051/tcp, 8008/tcp, 9000/tcp, 9000/udp, 0.0.0.0:9001->9001/tcp, 0.0.0.0:9001->9001/udp   stereum-731c4b72-7f7c-11ec-b824-c304f53cda24"
          ]
      }
  }
  ok: [manage-service--ssv-teku--ubuntu-20.04] => {
      "msg": {
          "changed": true,
          "cmd": "docker ps",
          "delta": "0:00:00.162041",
          "end": "2022-02-02 17:41:09.992004",
          "failed": false,
          "msg": "",
          "rc": 0,
          "start": "2022-02-02 17:41:09.829963",
          "stderr": "",
          "stderr_lines": [],
          "stdout": "CONTAINER ID   IMAGE                                COMMAND                  CREATED          STATUS                                  PORTS                                                                                    NAMES\nb0728ec9de39   bloxstaking/ssv-node:latest-ubuntu   \"bash -c 'touch /dat…\"   9 seconds ago    Restarting (2) Less than a second ago                                                                                            stereum-f6a89270-7fa4-11ec-9378-fbd364d02350\n5375fc9bd361   consensys/teku:21.12.2               \"/opt/teku/bin/teku …\"   49 seconds ago   Up 49 seconds                           5051/tcp, 8008/tcp, 9000/tcp, 9000/udp, 0.0.0.0:9001->9001/tcp, 0.0.0.0:9001->9001/udp   stereum-731c4b72-7f7c-11ec-b824-c304f53cda24",
          "stdout_lines": [
              "CONTAINER ID   IMAGE                                COMMAND                  CREATED          STATUS                                  PORTS                                                                                    NAMES",
              "b0728ec9de39   bloxstaking/ssv-node:latest-ubuntu   \"bash -c 'touch /dat…\"   9 seconds ago    Restarting (2) Less than a second ago                                                                                            stereum-f6a89270-7fa4-11ec-9378-fbd364d02350",
              "5375fc9bd361   consensys/teku:21.12.2               \"/opt/teku/bin/teku …\"   49 seconds ago   Up 49 seconds                           5051/tcp, 8008/tcp, 9000/tcp, 9000/udp, 0.0.0.0:9001->9001/tcp, 0.0.0.0:9001->9001/udp   stereum-731c4b72-7f7c-11ec-b824-c304f53cda24"
          ]
      }
  }
  
  TASK [assert] ******************************************************************
  fatal: [manage-service--ssv-teku--centos-stream-8]: FAILED! => {
      "assertion": "stereum_docker_ps.stdout.find(\"12000->12000\") != -1",
      "changed": false,
      "evaluated_to": false,
      "msg": "Assertion failed"
  }
  fatal: [manage-service--ssv-teku--ubuntu-20.04]: FAILED! => {
      "assertion": "stereum_docker_ps.stdout.find(\"12000->12000\") != -1",
      "changed": false,
      "evaluated_to": false,
      "msg": "Assertion failed"
  }
```
https://github.com/stereum-dev/ethereum-node/runs/5039289807?check_suite_focus=true#step:7:602