### PR TITLE
FIX:yum only when centos

### DIFF
--- a/controls/roles/setup/tasks/main.yml
+++ b/controls/roles/setup/tasks/main.yml
@@ -14,6 +14,7 @@
 - include_tasks: docker.yml
 
 - include_tasks: zip-centos.yml
+  when: ansible_distribution == "CentOS"
 
 - include_tasks: add-stereum-user.yml
 


### PR DESCRIPTION
forgot to filter for centos when installing packages via `yum`