### PR TITLE
FIX:molecule static geth & docker log verify

### DIFF
--- a/controls/roles/manage-service/molecule/ssv-lighthouse/converge.yml
+++ b/controls/roles/manage-service/molecule/ssv-lighthouse/converge.yml
@@ -33,7 +33,7 @@
                     Network: "prater"
                     BeaconNodeAddr: "http://stereum-{{ beacon_service }}:5052"
                   eth1:
-                    ETH1Addr: "wss://goerli.infura.io/ws/v3/20fd3ed2418742e9b727857e32b40f9c"
+                    ETH1Addr: "ws://10.10.0.2:8545"
                     RegistryContractAddr: "0x687fb596F3892904F879118e2113e1EEe8746C2E"
                   OperatorPrivateKey: ""
                   global:

--- a/controls/roles/manage-service/molecule/ssv-lighthouse/create.yml
+++ b/controls/roles/manage-service/molecule/ssv-lighthouse/create.yml
@@ -53,6 +53,15 @@
       retries: 300
       with_items: "{{ server.results }}"
 
+    - name: Attach Server to Subnetwork(s)
+      hcloud_server_network:
+        network: "{{ item.network.name }}"
+        server: "{{ item.name }}"
+        ip: "{{ item.network.ip }}"
+        api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"
+        state: "present"
+      loop: "{{ molecule_yml.platforms }}"
+
     - name: Populate instance config dict
       set_fact:
         instance_conf_dict: {

--- a/controls/roles/manage-service/molecule/ssv-lighthouse/molecule.yml
+++ b/controls/roles/manage-service/molecule/ssv-lighthouse/molecule.yml
@@ -8,10 +8,18 @@ platforms:
     hostname: ubuntu
     server_type: cpx31
     image: ubuntu-20.04
+    network:
+      name: eth2-prater
+      ip_range: 10.10.0.0/24
+      ip: 10.10.0.105
   - name: "manage-service--ssv-lighthouse--centos-stream-8"
     hostname: "centos"
     server_type: cpx31
     image: centos-stream-8
+    network:
+      name: eth2-prater
+      ip_range: 10.10.0.0/24
+      ip: 10.10.0.106
 provisioner:
   name: ansible
   config_options:

--- a/controls/roles/manage-service/molecule/ssv-lighthouse/prepare.yml
+++ b/controls/roles/manage-service/molecule/ssv-lighthouse/prepare.yml
@@ -56,7 +56,7 @@
               env:
                 DEBUG_LEVEL: debug
                 NETWORK: prater
-                ETH1_NODES: wss://goerli.infura.io/ws/v3/20fd3ed2418742e9b727857e32b40f9c
+                ETH1_NODES: http://10.10.0.3:8545
                 DATADIR: /opt/app/beacon
                 SLASHERDIR: /opt/app/slasher
                 SLASHER_DB_SIZE: "16"

--- a/controls/roles/manage-service/molecule/ssv-lighthouse/verify.yml
+++ b/controls/roles/manage-service/molecule/ssv-lighthouse/verify.yml
@@ -32,15 +32,17 @@
       minutes: 10
   # lh beacon & ssv logs
   - name: Lighthouse beacon node
-    ansible.builtin.shell: docker logs --tail=150 stereum-d00ff1ae-7161-11ec-915c-0f48d393560f
+    command: "docker logs --tail=150 stereum-d00ff1ae-7161-11ec-915c-0f48d393560f"
     register: beacon
-    until: beacon.stdout.find("est_time") == -1
+    until: beacon.stderr is not search('est_time')
     retries: 360
     delay: 10
   - name: Blox-SSV
-    ansible.builtin.shell: docker logs --tail=100 stereum-1ce654a0-7162-11ec-91f3-8fdbc286367e
+    command: "docker logs --tail=250 stereum-1ce654a0-7162-11ec-91f3-8fdbc286367e"
     register: blox_ssv
-    until: blox_ssv.stdout.find("beacon node is not healthy") == -1
+    until:
+      - blox_ssv.stderr.find("beacon node is not healthy") == -1
+      - blox_ssv.stderr.find("at peer limit") != -1
     retries: 360
     delay: 10
   # container's images & ports
@@ -55,5 +57,6 @@
       - stereum_docker_ps.stdout.find("9000->9000") != -1
       - stereum_docker_ps.stdout.find("12000->12000") != -1
       - stereum_docker_ps.stdout.find("13000->13000") != -1
+      - (stereum_docker_ps.stdout|regex_findall("Up")|length) == 2
 
 # EOF

--- a/controls/roles/manage-service/molecule/ssv-nimbus/converge.yml
+++ b/controls/roles/manage-service/molecule/ssv-nimbus/converge.yml
@@ -33,7 +33,7 @@
                     Network: "prater"
                     BeaconNodeAddr: "http://stereum-{{ beacon_service }}:5052"
                   eth1:
-                    ETH1Addr: "wss://goerli.infura.io/ws/v3/20fd3ed2418742e9b727857e32b40f9c"
+                    ETH1Addr: "ws://10.10.0.2:8545"
                     RegistryContractAddr: "0x687fb596F3892904F879118e2113e1EEe8746C2E"
                   OperatorPrivateKey: ""
                   global:

--- a/controls/roles/manage-service/molecule/ssv-nimbus/create.yml
+++ b/controls/roles/manage-service/molecule/ssv-nimbus/create.yml
@@ -53,6 +53,15 @@
       retries: 300
       with_items: "{{ server.results }}"
 
+    - name: Attach Server to Subnetwork(s)
+      hcloud_server_network:
+        network: "{{ item.network.name }}"
+        server: "{{ item.name }}"
+        ip: "{{ item.network.ip }}"
+        api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"
+        state: "present"
+      loop: "{{ molecule_yml.platforms }}"
+
     - name: Populate instance config dict
       set_fact:
         instance_conf_dict: {
@@ -61,7 +70,8 @@
           'address': "{{ item.hcloud_server.ipv4_address }}",
           'user': "{{ ssh_user }}",
           'port': "{{ ssh_port }}",
-          'identity_file': "{{ ssh_path }}", }
+          'identity_file': "{{ ssh_path }}",
+        }
       with_items: "{{ hetzner_jobs.results }}"
       register: instance_config_dict
       when: server.changed | bool

--- a/controls/roles/manage-service/molecule/ssv-nimbus/molecule.yml
+++ b/controls/roles/manage-service/molecule/ssv-nimbus/molecule.yml
@@ -8,10 +8,18 @@ platforms:
     hostname: ubuntu
     server_type: cpx31
     image: ubuntu-20.04
+    network:
+      name: eth2-prater
+      ip_range: 10.10.0.0/24
+      ip: 10.10.0.100
   - name: "manage-service--ssv-nimbus--centos-stream-8"
     hostname: "centos"
     server_type: cpx31
     image: centos-stream-8
+    network:
+      name: eth2-prater
+      ip_range: 10.10.0.0/24
+      ip: 10.10.0.101
 provisioner:
   name: ansible
   config_options:

--- a/controls/roles/manage-service/molecule/ssv-nimbus/prepare.yml
+++ b/controls/roles/manage-service/molecule/ssv-nimbus/prepare.yml
@@ -62,7 +62,7 @@
               command:
                 - --network=prater
                 - --data-dir=/opt/app/beacon
-                - --web3-url=wss://goerli.infura.io/ws/v3/20fd3ed2418742e9b727857e32b40f9c
+                - --web3-url=ws://10.10.0.2:8545
                 - --tcp-port=9000
                 - --udp-port=9000
                 - --rpc

--- a/controls/roles/manage-service/molecule/ssv-nimbus/verify.yml
+++ b/controls/roles/manage-service/molecule/ssv-nimbus/verify.yml
@@ -32,15 +32,15 @@
       minutes: 10
   # nimbus beacon & ssv logs
   - name: nimbus beacon node
-    ansible.builtin.shell: docker logs --tail=150 stereum-493f2578-7e13-11ec-80bb-1b593d9699ff
+    command: "docker logs --tail=250 stereum-493f2578-7e13-11ec-80bb-1b593d9699ff"
     register: beacon
-    until: beacon.stdout.find("sync=synced") != -1
+    until: beacon.stderr.find("sync=synced") != -1
     retries: 360
     delay: 10
   - name: Blox-SSV
-    ansible.builtin.shell: docker logs --tail=100 stereum-52d77bd0-7e13-11ec-a95e-bb669ccf3e66
+    command: "docker logs --tail=100 stereum-52d77bd0-7e13-11ec-a95e-bb669ccf3e66"
     register: blox_ssv
-    until: blox_ssv.stdout.find("beacon node is not healthy") == -1
+    until: blox_ssv.stderr.find("beacon node is not healthy") == -1
     retries: 360
     delay: 10
   # container's images & ports
@@ -56,5 +56,6 @@
       - stereum_docker_ps.stdout.find("9190->9190") != -1
       - stereum_docker_ps.stdout.find("12000->12000") != -1
       - stereum_docker_ps.stdout.find("13000->13000") != -1
+      - (stereum_docker_ps.stdout|regex_findall("Up")|length) == 2
 
 # EOF

--- a/controls/roles/manage-service/molecule/ssv-teku/converge.yml
+++ b/controls/roles/manage-service/molecule/ssv-teku/converge.yml
@@ -33,7 +33,7 @@
                     Network: "prater"
                     BeaconNodeAddr: "http://stereum-{{ beacon_service }}:5051"
                   eth1:
-                    ETH1Addr: "wss://goerli.infura.io/ws/v3/20fd3ed2418742e9b727857e32b40f9c"
+                    ETH1Addr: "ws://10.10.0.2:8545"
                     RegistryContractAddr: "0x687fb596F3892904F879118e2113e1EEe8746C2E"
                   OperatorPrivateKey: ""
                   global:

--- a/controls/roles/manage-service/molecule/ssv-teku/create.yml
+++ b/controls/roles/manage-service/molecule/ssv-teku/create.yml
@@ -53,6 +53,15 @@
       retries: 300
       with_items: "{{ server.results }}"
 
+    - name: Attach Server to Subnetwork(s)
+      hcloud_server_network:
+        network: "{{ item.network.name }}"
+        server: "{{ item.name }}"
+        ip: "{{ item.network.ip }}"
+        api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"
+        state: "present"
+      loop: "{{ molecule_yml.platforms }}"
+
     - name: Populate instance config dict
       set_fact:
         instance_conf_dict: {

--- a/controls/roles/manage-service/molecule/ssv-teku/molecule.yml
+++ b/controls/roles/manage-service/molecule/ssv-teku/molecule.yml
@@ -8,10 +8,18 @@ platforms:
     hostname: ubuntu
     server_type: cpx31
     image: ubuntu-20.04
+    network:
+      name: eth2-prater
+      ip_range: 10.10.0.0/24
+      ip: 10.10.0.110
   - name: "manage-service--ssv-teku--centos-stream-8"
     hostname: "centos"
     server_type: cpx31
     image: centos-stream-8
+    network:
+      name: eth2-prater
+      ip_range: 10.10.0.0/24
+      ip: 10.10.0.111
 provisioner:
   name: ansible
   config_options:

--- a/controls/roles/manage-service/molecule/ssv-teku/prepare.yml
+++ b/controls/roles/manage-service/molecule/ssv-teku/prepare.yml
@@ -64,7 +64,7 @@
                 --network=prater
                 --p2p-enabled=true
                 --p2p-port=9001
-                --eth1-endpoint=https://goerli.infura.io/v3/20fd3ed2418742e9b727857e32b40f9c
+                --eth1-endpoint=http://10.10.0.3:8545
                 --metrics-enabled=true
                 --metrics-categories=BEACON,LIBP2P,NETWORK,PROCESS
                 --metrics-port=8008

--- a/controls/roles/manage-service/molecule/ssv-teku/verify.yml
+++ b/controls/roles/manage-service/molecule/ssv-teku/verify.yml
@@ -34,13 +34,13 @@
   - name: Teku beacon node
     ansible.builtin.shell: docker logs --tail=150 stereum-731c4b72-7f7c-11ec-b824-c304f53cda24
     register: beacon
-    until: beacon.stdout.find("Syncing") == -1
+    until: beacon.stderr.find("Syncing") == -1
     retries: 360
     delay: 10
   - name: Blox-SSV
     ansible.builtin.shell: docker logs --tail=100 stereum-f6a89270-7fa4-11ec-9378-fbd364d02350
     register: blox_ssv
-    until: blox_ssv.stdout.find("beacon node is not healthy") == -1
+    until: blox_ssv.stderr.find("beacon node is not healthy") == -1
     retries: 360
     delay: 10
   # container's images & ports
@@ -56,5 +56,6 @@
       - stereum_docker_ps.stdout.find("9001->9001") != -1
       - stereum_docker_ps.stdout.find("12000->12000") != -1
       - stereum_docker_ps.stdout.find("13000->13000") != -1
+      - (stereum_docker_ps.stdout|regex_findall("Up")|length) == 2
 
 # EOF


### PR DESCRIPTION
This PR addresses multiple issues:
- No need for infura.io eth1 addresses on github action hetzner vms, there are 2 Geth instances running on a private network `10.10.0.0/24` the test VMs can join. `10.10.0.2` for websocket and `10.10.0.3` for RESTful endpoints.
- Checking output of logs of running services in `stderr` instead of `stdout`. `docker logs` always writes to `stderr`, e. g. `docker ps` writes like everything else to `stdout´.