### PR TITLE
FIX: genericPlaybook.yaml throwing error on undefined args

### DIFF
--- a/controls/genericPlaybook.yaml
+++ b/controls/genericPlaybook.yaml
@@ -8,6 +8,9 @@
     - set_fact:
         stereum: "{{ stereum_static | combine(stereum_args, recursive=True) }}"
       when: stereum_args is defined
+    - set_fact:
+        stereum: "{{ stereum_static}}"
+      when: stereum_args is undefined
     - name: "Include role"
       include_role:
         name: "{{ stereum_role }}"


### PR DESCRIPTION
Role `setup` doesn't require any `stereum_args` and uses `stereum_static` instead, but `combine()` throws an error on undefined values.