### PR TITLE
FIX: geth config, fixes #202

### DIFF
--- a/launcher/src/backend/ethereum-services/GethService.js
+++ b/launcher/src/backend/ethereum-services/GethService.js
@@ -13,7 +13,7 @@ export class GethService extends NodeService {
             null,
             "ethereum/client-go",
             "v1.10.11",
-            "geth --" + network + " --http --http.port=8545 --http.addr=0.0.0.0 --http.vhosts='*' --allow-insecure-unlock --http.api='db,eth,net,web3,personal' --ws --ws.port=8546 --ws.addr=0.0.0.0 --ws.api='db,eth,net,web3' --ws.origins='*'",
+            "geth --" + network + " --http --http.port=8545 --http.addr=0.0.0.0 --http.vhosts=\"*\" --allow-insecure-unlock --http.api=\"db,eth,net,web3,personal\" --ws --ws.port=8546 --ws.addr=0.0.0.0 --ws.api=\"db,eth,net,web3\" --ws.origins=\"*\"",
             null,
             null,
             ports,


### PR DESCRIPTION
Geth config in `/etc/stereum/services` now looks like this:
```
command: geth --goerli --http --http.port=8545 --http.addr=0.0.0.0
  --http.vhosts="*" --allow-insecure-unlock
  --http.api="db,eth,net,web3,personal" --ws --ws.port=8546 --ws.addr=0.0.0.0
  --ws.api="db,eth,net,web3" --ws.origins="*"
```