### PR TITLE
FIX: force test vms to hel1 to connect to geth

### DIFF
--- a/controls/roles/fastsync/molecule/default/create.yml
+++ b/controls/roles/fastsync/molecule/default/create.yml
@@ -35,7 +35,7 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "{{ item.location | default(omit) }}"
+        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/monitor-lighthouse/create.yml
+++ b/controls/roles/manage-service/molecule/monitor-lighthouse/create.yml
@@ -35,7 +35,7 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "{{ item.location | default(omit) }}"
+        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/monitor-nimbus/create.yml
+++ b/controls/roles/manage-service/molecule/monitor-nimbus/create.yml
@@ -35,7 +35,7 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "{{ item.location | default(omit) }}"
+        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/ssv-lighthouse/create.yml
+++ b/controls/roles/manage-service/molecule/ssv-lighthouse/create.yml
@@ -35,7 +35,7 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "{{ item.location | default(omit) }}"
+        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/ssv-nimbus/create.yml
+++ b/controls/roles/manage-service/molecule/ssv-nimbus/create.yml
@@ -35,7 +35,7 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "{{ item.location | default(omit) }}"
+        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/ssv-prysm/create.yml
+++ b/controls/roles/manage-service/molecule/ssv-prysm/create.yml
@@ -35,7 +35,7 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "{{ item.location | default(omit) }}"
+        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/ssv-teku/create.yml
+++ b/controls/roles/manage-service/molecule/ssv-teku/create.yml
@@ -35,7 +35,7 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "{{ item.location | default(omit) }}"
+        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/start-multiple/create.yml
+++ b/controls/roles/manage-service/molecule/start-multiple/create.yml
@@ -35,7 +35,7 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "{{ item.location | default(omit) }}"
+        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/start-stop/create.yml
+++ b/controls/roles/manage-service/molecule/start-stop/create.yml
@@ -35,7 +35,7 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "{{ item.location | default(omit) }}"
+        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/start/create.yml
+++ b/controls/roles/manage-service/molecule/start/create.yml
@@ -35,7 +35,7 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "{{ item.location | default(omit) }}"
+        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/write-start/create.yml
+++ b/controls/roles/manage-service/molecule/write-start/create.yml
@@ -35,7 +35,7 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "{{ item.location | default(omit) }}"
+        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/setup/molecule/default/create.yml
+++ b/controls/roles/setup/molecule/default/create.yml
@@ -35,7 +35,7 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "{{ item.location | default(omit) }}"
+        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/update-services/molecule/default/create.yml
+++ b/controls/roles/update-services/molecule/default/create.yml
@@ -35,7 +35,7 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "{{ item.location | default(omit) }}"
+        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/validator-import-api/molecule/lighthouse/create.yml
+++ b/controls/roles/validator-import-api/molecule/lighthouse/create.yml
@@ -35,7 +35,7 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "{{ item.location | default(omit) }}"
+        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/validator-import-api/molecule/nimbus/create.yml
+++ b/controls/roles/validator-import-api/molecule/nimbus/create.yml
@@ -35,7 +35,7 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "{{ item.location | default(omit) }}"
+        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/validator-import-api/molecule/prysm/create.yml
+++ b/controls/roles/validator-import-api/molecule/prysm/create.yml
@@ -35,7 +35,7 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "{{ item.location | default(omit) }}"
+        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/validator-import-lighthouse/molecule/default/create.yml
+++ b/controls/roles/validator-import-lighthouse/molecule/default/create.yml
@@ -35,7 +35,7 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "{{ item.location | default(omit) }}"
+        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/validator-import-nimbus/molecule/default/create.yml
+++ b/controls/roles/validator-import-nimbus/molecule/default/create.yml
@@ -35,7 +35,7 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "{{ item.location | default(omit) }}"
+        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/validator-import-prysm/molecule/default/create.yml
+++ b/controls/roles/validator-import-prysm/molecule/default/create.yml
@@ -35,7 +35,7 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "{{ item.location | default(omit) }}"
+        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/validator-import-teku/molecule/default/create.yml
+++ b/controls/roles/validator-import-teku/molecule/default/create.yml
@@ -35,7 +35,7 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "{{ item.location | default(omit) }}"
+        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"


### PR DESCRIPTION
I found that the VMs having trouble to connect to the virtual network were only in the US, according to the documentation [here](https://docs.hetzner.cloud/#network-zones) the virtual networks in US don't connect to the ones in Europe.

This hopefully fixes the issue we have with attaching the molecule test vms to the virtual network for execution client connections.