### PR TITLE
ADD: config version for service yamls

### DIFF
--- a/launcher/src/backend/ethereum-services/BloxSSVService.js
+++ b/launcher/src/backend/ethereum-services/BloxSSVService.js
@@ -51,6 +51,7 @@ MetricsAPIPort: 15000
     service.init(
       'BloxSSVService',
       null,
+      1,
       'bloxstaking/ssv-node',
       'ubuntu-latest',
       null,

--- a/launcher/src/backend/ethereum-services/BloxSSVService.test.js
+++ b/launcher/src/backend/ethereum-services/BloxSSVService.test.js
@@ -50,6 +50,7 @@ test('buildConfiguration', () => {
   expect(bloxService.id).toHaveLength(36)
   expect(bloxService.user).toMatch(/root/)
   expect(bloxService.image).toMatch(/bloxstaking\/ssv-node/)
+  expect(bloxService.configVersion).toBe(1)
 })
 
 test('getServiceConfiguration', () => {

--- a/launcher/src/backend/ethereum-services/GethService.js
+++ b/launcher/src/backend/ethereum-services/GethService.js
@@ -11,6 +11,7 @@ export class GethService extends NodeService {
     service.init(
       'GethService',
       null,
+      1,
       'ethereum/client-go',
       'v1.10.11',
       'geth --' + network + ' --http --http.port=8545 --http.addr=0.0.0.0 --http.vhosts="*" --allow-insecure-unlock --http.api="debug,eth,net,web3,personal" --ws --ws.port=8546 --ws.addr=0.0.0.0 --ws.api="debug,eth,net,web3" --ws.origins="*"',

--- a/launcher/src/backend/ethereum-services/GethService.test.js
+++ b/launcher/src/backend/ethereum-services/GethService.test.js
@@ -70,11 +70,13 @@ test('buildByConfiguration', () => {
   const gethConfig = GethService.buildByConfiguration({
     id: '987',
     service: 'GethService',
+    configVersion: 1,
     image: 'geth:v0.0.1'
   }).buildConfiguration()
 
   expect(gethConfig.id).toBe('987')
   expect(gethConfig.service).toBe('GethService')
+  expect(gethConfig.configVersion).toBe(1)
 })
 
 // EOF

--- a/launcher/src/backend/ethereum-services/GrafanaService.js
+++ b/launcher/src/backend/ethereum-services/GrafanaService.js
@@ -20,6 +20,7 @@ export class GrafanaService extends NodeService {
     service.init(
       'GrafanaService',
       null, // id
+      1, // configVersion
       image, // image
       '8.4.0', // imageVersion
       'bash -c "touch /etc/grafana/grafana.ini && echo \\"$GRAFANA_INI\\" > /etc/grafana/grafana.ini && /run.sh"', // command

--- a/launcher/src/backend/ethereum-services/GrafanaService.test.js
+++ b/launcher/src/backend/ethereum-services/GrafanaService.test.js
@@ -20,6 +20,7 @@ test('buildConfiguration', () => {
   expect(grafanaService.id).toHaveLength(36)
   expect(grafanaService.user).toMatch(/2000/)
   expect(grafanaService.image).toMatch(/grafana\/grafana/)
+  expect(grafanaService.configVersion).toBe(1)
 })
 
 test('getAvailablePorts', () => {
@@ -32,6 +33,7 @@ test('buildByConfiguration', () => {
   const grafana = GrafanaService.buildByConfiguration({
     id: '123',
     service: 'GrafanaService',
+    configVersion: 999,
     image: 'grafana:v8.4.0',
     ports: ['0.0.0.0:1234:5678/tcp', '8.8.8.8:1234:5678/udp'],
     volumes: ['/opt/stereum/foo:/opt/app/data']
@@ -39,6 +41,7 @@ test('buildByConfiguration', () => {
 
   expect(grafana.id).toBe('123')
   expect(grafana.service).toBe('GrafanaService')
+  expect(grafana.configVersion).toBe(999)
   expect(grafana.image).toBe('grafana')
   expect(grafana.imageVersion).toBe('v8.4.0')
   expect(grafana.ports).toHaveLength(2)

--- a/launcher/src/backend/ethereum-services/LighthouseBeaconService.js
+++ b/launcher/src/backend/ethereum-services/LighthouseBeaconService.js
@@ -22,6 +22,7 @@ export class LighthouseBeaconService extends NodeService {
     service.init(
       'LighthouseBeaconService',  //service
       null, //id
+      1, // configVersion
       image,  //image
       'v2.1.2', //imageVersion
       [

--- a/launcher/src/backend/ethereum-services/LighthouseBeaconService.test.js
+++ b/launcher/src/backend/ethereum-services/LighthouseBeaconService.test.js
@@ -35,6 +35,7 @@ test('buildConfiguration', () => {
   expect(lhService.id).toHaveLength(36)
   expect(lhService.user).toMatch(/2000/)
   expect(lhService.image).toMatch(/sigp\/lighthouse/)
+  expect(lhService.configVersion).toBe(1)
 })
 
 test('buildConsensusClientHttpEndpointUrl', () => {
@@ -80,6 +81,7 @@ test('buildByConfiguration', () => {
   const lh = LighthouseBeaconService.buildByConfiguration({
     id: '123',
     service: 'LighthouseBeaconService',
+    configVersion: 678,
     image: 'lhbeacon:v0.0.1',
     ports: ['0.0.0.0:1234:5678/tcp', '8.8.8.8:1234:5678/udp'],
     volumes: ['/opt/stereum/foo:/opt/app/data']
@@ -87,6 +89,7 @@ test('buildByConfiguration', () => {
 
   expect(lh.id).toBe('123')
   expect(lh.service).toBe('LighthouseBeaconService')
+  expect(lh.configVersion).toBe(678)
   expect(lh.image).toBe('lhbeacon')
   expect(lh.imageVersion).toBe('v0.0.1')
   expect(lh.ports).toHaveLength(2)

--- a/launcher/src/backend/ethereum-services/LighthouseValidatorService.js
+++ b/launcher/src/backend/ethereum-services/LighthouseValidatorService.js
@@ -5,9 +5,9 @@ import { ServiceVolume } from './ServiceVolume.js'
 
 export class LighthouseValidatorService extends NodeService {
   static buildByUserInput (network, ports, workingDir, consensusClients, graffiti) {
-    
+
     const image = 'sigp/lighthouse'
-    
+
     const dataDir = '/opt/app/validator'
 
     const volumes = [
@@ -21,6 +21,7 @@ export class LighthouseValidatorService extends NodeService {
     service.init(
       'LighthouseValidatorService', //service
       null, //id
+      1, //configVersion
       image,  //image
       'v2.1.2', //imageVersion
       [

--- a/launcher/src/backend/ethereum-services/LighthouseValidatorService.test.js
+++ b/launcher/src/backend/ethereum-services/LighthouseValidatorService.test.js
@@ -34,6 +34,7 @@ test('LighthouseValidatorService buildConfiguration', () => {
   expect(lhService.id).toHaveLength(36)
   expect(lhService.user).toMatch(/2000/)
   expect(lhService.image).toMatch(/sigp\/lighthouse/)
+  expect(lhService.configVersion).toBe(1)
 
   expect(lhService.service).toMatch(/LighthouseValidatorService/)
 })
@@ -72,6 +73,7 @@ test('buildByConfiguration', () => {
   const lh = LighthouseValidatorService.buildByConfiguration({
     id: '123',
     service: 'LighthouseValidatorService',
+    configVersion: 333,
     image: 'lhval:v0.0.1',
     command:[
       'lighthouse',
@@ -92,6 +94,7 @@ test('buildByConfiguration', () => {
 
   expect(lh.id).toBe('123')
   expect(lh.service).toBe('LighthouseValidatorService')
+  expect(lh.configVersion).toBe(333)
   expect(lh.image).toBe('lhval')
   expect(lh.imageVersion).toBe('v0.0.1')
   expect(lh.ports).toHaveLength(0)

--- a/launcher/src/backend/ethereum-services/NimbusBeaconService.js
+++ b/launcher/src/backend/ethereum-services/NimbusBeaconService.js
@@ -21,6 +21,7 @@ export class NimbusBeaconService extends NodeService {
     service.init(
       'NimbusBeaconService',  //service
       null, // id,
+      1, // configVersion
       image, // image,
       'multiarch-v22.3.0', // imageVersion,
       [

--- a/launcher/src/backend/ethereum-services/NimbusBeaconService.test.js
+++ b/launcher/src/backend/ethereum-services/NimbusBeaconService.test.js
@@ -37,6 +37,7 @@ test('buildConfiguration', () => {
   expect(nimbusService.id).toHaveLength(36)
   expect(nimbusService.user).toMatch(/2000/)
   expect(nimbusService.image).toMatch(/statusim\/nimbus-eth2/)
+  expect(nimbusService.configVersion).toBe(1)
 })
 
 test('buildConsensusClientHttpEndpointUrl', () => {
@@ -76,6 +77,7 @@ test('buildByConfiguration', () => {
   const nimbus = NimbusBeaconService.buildByConfiguration({
     id: '123',
     service: 'NimbusBeaconService',
+    configVersion: 234,
     image: 'nimbusbeacon:v0.0.1',
     ports: ['0.0.0.0:1234:5678/tcp', '8.8.8.8:1234:5678/udp'],
     volumes: ['/opt/stereum/foo:/opt/app/data']
@@ -83,6 +85,7 @@ test('buildByConfiguration', () => {
 
   expect(nimbus.id).toBe('123')
   expect(nimbus.service).toBe('NimbusBeaconService')
+  expect(nimbus.configVersion).toBe(234)
   expect(nimbus.image).toBe('nimbusbeacon')
   expect(nimbus.imageVersion).toBe('v0.0.1')
   expect(nimbus.ports).toHaveLength(2)

--- a/launcher/src/backend/ethereum-services/NodeService.js
+++ b/launcher/src/backend/ethereum-services/NodeService.js
@@ -29,9 +29,10 @@ export class NodeService {
     }
   }
 
-  init (service, id, image, imageVersion, command, entrypoint, env, ports, volumes, user, network, executionClients, consensusClients, prometheusNodeExporterClients) {
+  init (service, id, configVersion, image, imageVersion, command, entrypoint, env, ports, volumes, user, network, executionClients, consensusClients, prometheusNodeExporterClients) {
     this.service = service
     this.setId(id)
+    this.configVersion = configVersion
     this.image = image
     this.imageVersion = imageVersion
     this.command = (command === undefined || command === null) ? [] : command
@@ -54,6 +55,7 @@ export class NodeService {
 
     this.setId(config.id)
     this.service = config.service
+    this.configVersion = config.configVersion
     this.image = imageInformation.image
     this.imageVersion = imageInformation.version
     this.command = config.command
@@ -79,6 +81,7 @@ export class NodeService {
     return {
       service: this.service,
       id: this.id,
+      configVersion: this.configVersion,
       command: this.command,
       entrypoint: this.entrypoint,
       env: this.env,

--- a/launcher/src/backend/ethereum-services/PrometheusNodeExporterService.js
+++ b/launcher/src/backend/ethereum-services/PrometheusNodeExporterService.js
@@ -9,6 +9,7 @@ export class PrometheusNodeExporterService extends NodeService {
     service.init(
       'PrometheusNodeExporterService',
       null, // id
+      1, // configVersion
       image, // image
       'v1.3.1', // imageVersion
       null, // command

--- a/launcher/src/backend/ethereum-services/PrometheusNodeExporterService.test.js
+++ b/launcher/src/backend/ethereum-services/PrometheusNodeExporterService.test.js
@@ -23,6 +23,7 @@ test('buildByConfiguration', () => {
 
   expect(pne.id).toBe('123')
   expect(pne.service).toBe('PrometheusNodeExporterService')
+  expect(pne.configVersion).toBe(1)
   expect(pne.image).toBe('prom/node-exporter')
   expect(pne.imageVersion).toBe('v0.0.1')
   expect(pne.ports).toHaveLength(2)

--- a/launcher/src/backend/ethereum-services/PrometheusNodeExporterService.test.js
+++ b/launcher/src/backend/ethereum-services/PrometheusNodeExporterService.test.js
@@ -16,6 +16,7 @@ test('buildByConfiguration', () => {
   const pne = PrometheusNodeExporterService.buildByConfiguration({
     id: '123',
     service: 'PrometheusNodeExporterService',
+    configVersion: 654,
     image: 'prom/node-exporter:v0.0.1',
     ports: ['0.0.0.0:1234:5678/tcp', '8.8.8.8:1234:5678/udp'],
     volumes: ['/opt/stereum/foo:/opt/app/data']
@@ -23,7 +24,7 @@ test('buildByConfiguration', () => {
 
   expect(pne.id).toBe('123')
   expect(pne.service).toBe('PrometheusNodeExporterService')
-  expect(pne.configVersion).toBe(1)
+  expect(pne.configVersion).toBe(654)
   expect(pne.image).toBe('prom/node-exporter')
   expect(pne.imageVersion).toBe('v0.0.1')
   expect(pne.ports).toHaveLength(2)

--- a/launcher/src/backend/ethereum-services/PrometheusService.js
+++ b/launcher/src/backend/ethereum-services/PrometheusService.js
@@ -25,6 +25,7 @@ export class PrometheusService extends NodeService {
     service.init(
       'PrometheusService',
       null, // id
+      1, // configVersion
       image, // image
       'v2.33.1', // imageVersion
       'sh -c "touch /etc/prometheus/prometheus.yml && echo \\"$CONFIG\\" > /etc/prometheus/prometheus.yml && /bin/prometheus --config.file=/etc/prometheus/prometheus.yml"', // command

--- a/launcher/src/backend/ethereum-services/PrometheusService.test.js
+++ b/launcher/src/backend/ethereum-services/PrometheusService.test.js
@@ -65,6 +65,7 @@ test('buildConfiguration', () => {
   expect(prometheus.id).toHaveLength(36)
   expect(prometheus.user).toMatch(/2000/)
   expect(prometheus.image).toMatch(/prom\/prometheus/)
+  expect(prometheus.configVersion).toBe(1)
 })
 
 test('getAvailablePorts', () => {
@@ -77,6 +78,7 @@ test('buildByConfiguration', () => {
   const prometheus = PrometheusService.buildByConfiguration({
     id: '123',
     service: 'PrometheusService',
+    configVersion: 876,
     image: 'prometheus:v0.0.1',
     ports: ['0.0.0.0:1234:5678/tcp', '8.8.8.8:1234:5678/udp'],
     volumes: ['/opt/stereum/foo:/opt/app/data']
@@ -84,6 +86,7 @@ test('buildByConfiguration', () => {
 
   expect(prometheus.id).toBe('123')
   expect(prometheus.service).toBe('PrometheusService')
+  expect(prometheus.configVersion).toBe(1)
   expect(prometheus.image).toBe('prometheus')
   expect(prometheus.imageVersion).toBe('v0.0.1')
   expect(prometheus.ports).toHaveLength(2)

--- a/launcher/src/backend/ethereum-services/PrometheusService.test.js
+++ b/launcher/src/backend/ethereum-services/PrometheusService.test.js
@@ -86,7 +86,7 @@ test('buildByConfiguration', () => {
 
   expect(prometheus.id).toBe('123')
   expect(prometheus.service).toBe('PrometheusService')
-  expect(prometheus.configVersion).toBe(1)
+  expect(prometheus.configVersion).toBe(876)
   expect(prometheus.image).toBe('prometheus')
   expect(prometheus.imageVersion).toBe('v0.0.1')
   expect(prometheus.ports).toHaveLength(2)


### PR DESCRIPTION
This is necessary to update config files when breaking changes happen for Stereum versions as well as service versions.

fixes #137 