### PR TITLE
FIX: ssv-prysm eth1 link

### DIFF
--- a/controls/roles/manage-service/molecule/ssv-prysm/prepare.yml
+++ b/controls/roles/manage-service/molecule/ssv-prysm/prepare.yml
@@ -13,7 +13,7 @@
         Network: "prater"
         BeaconNodeAddr: "http://stereum-{{ beacon_service }}:3500"
       eth1:
-        ETH1Addr: "ws://10.10.0.3:8545"
+        ETH1Addr: "ws://10.10.0.2:8545"
         RegistryContractAddr: "0x687fb596F3892904F879118e2113e1EEe8746C2E"
       OperatorPrivateKey: ""
       global:


### PR DESCRIPTION
error: `could not connect to the eth1 client` https://github.com/stereum-dev/ethereum-node/runs/6425742182?check_suite_focus=true#step:8:1121