### PR TITLE
ADD: patches for updates

### DIFF
--- a/controls/finishUpdate.yaml
+++ b/controls/finishUpdate.yaml
@@ -1,0 +1,16 @@
+---
+- name: "finishUpdate"
+  hosts: localhost
+  vars_files:
+  - defaults/stereum_defaults.yaml # stereum_static
+  - /etc/stereum/stereum.yaml # stereum_settings
+
+  tasks:
+    # merge default config with node's config
+    - set_fact:
+        stereum: "{{ stereum_settings | combine(stereum_static, recursive=True) }}"
+
+    - debug:
+       msg: "applied all patches"
+
+#EOF

--- a/controls/unattended-update.sh
+++ b/controls/unattended-update.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 if ansible-playbook -v genericPlaybook.yaml --extra-vars "stereum_role=update-stereum"; then
+  ansible-playbook -v finishUpdate.yaml
   ansible-playbook -v genericPlaybook.yaml --extra-vars "stereum_role=update-services"
 fi
 


### PR DESCRIPTION
This PR introduces a way to implement patches running custom ansible roles & tasks on update via `controls/finishUpdate.yaml`. Similar process is used in Stereum version 1.x