### PR TITLE
FIX: molecule tests now use versions of defaults

### DIFF
--- a/controls/defaults/stereum_defaults.yaml
+++ b/controls/defaults/stereum_defaults.yaml
@@ -7,8 +7,20 @@ stereum_static:
       unattended:
         install: false
     versions:
+      # consensus clients
       lighthouse: v2.3.1
       nimbus: multiarch-v22.6.0
       teku: "22.6.0"
       prysm: v2.1.2
+
+      # execution clients
+      geth: v1.10.19
+
+      # ssv
+      blox_ssv: v0.2.0
+
+      # tools
       curl: "7.83.1"
+      grafana: "8.5.6"
+      node_exporter: v1.3.1
+      prometheus: v2.36.2

--- a/controls/roles/fastsync/molecule/default/prepare.yml
+++ b/controls/roles/fastsync/molecule/default/prepare.yml
@@ -10,6 +10,9 @@
     beacon_service: 9024aec6-12a8-456a-8096-ee7ef6f67167
 
   tasks:
+    - set_fact:
+        stereum: "{{ stereum_static }}"
+
     - name: Install python for Ansible (Ubuntu)
       raw: apt update && apt install -y pip
       become: true
@@ -34,7 +37,7 @@
         content: |
           name: lighthouse
           id: "{{ beacon_service }}"
-          image: sigp/lighthouse:v2.1.2
+          image: "sigp/lighthouse:{{ stereum.defaults.versions.lighthouse }}"
           env: {}
           ports:
           - 0.0.0.0:9000:9000/tcp

--- a/controls/roles/manage-service/molecule/geth/converge.yml
+++ b/controls/roles/manage-service/molecule/geth/converge.yml
@@ -21,7 +21,7 @@
             state: started
             configuration:
               id: "{{ geth_service }}"
-              image: ethereum/client-go:v1.10.18
+              image: "ethereum/client-go:{{ stereum.defaults.versions.geth }}"
               ports:
                 - 0.0.0.0:30303:30303/tcp
                 - 0.0.0.0:30303:30303/udp

--- a/controls/roles/manage-service/molecule/geth/prepare.yml
+++ b/controls/roles/manage-service/molecule/geth/prepare.yml
@@ -42,7 +42,7 @@
             state: started
             configuration:
               id: "{{ beacon_service }}"
-              image: sigp/lighthouse:v2.1.2
+              image: "sigp/lighthouse:{{ stereum.defaults.versions.lighthouse }}"
               env: {}
               ports:
                 - 0.0.0.0:9000:9000/tcp

--- a/controls/roles/manage-service/molecule/monitor-lighthouse/converge.yml
+++ b/controls/roles/manage-service/molecule/monitor-lighthouse/converge.yml
@@ -25,7 +25,7 @@
             state: started
             configuration:
               id: "{{ prometheus_service }}"
-              image: prom/prometheus:v2.33.1
+              image: "prom/prometheus:{{ stereum.defaults.versions.prometheus }}"
               ports:
                 - 127.0.0.1:9090:9090/tcp
               env:
@@ -73,7 +73,7 @@
             state: started
             configuration:
               id: "{{ prometheus_node_exporter_service }}"
-              image: prom/node-exporter:v1.3.1
+              image: "prom/node-exporter:{{ stereum.defaults.versions.node_exporter }}"
               ports: []
               env: {}
               command: []
@@ -94,7 +94,7 @@
             state: started
             configuration:
               id: "{{ grafana_service }}"
-              image: grafana/grafana:8.4.0
+              image: "grafana/grafana:{{ stereum.defaults.versions.grafana }}"
               ports:
                 - 127.0.0.1:3000:3000/tcp
               env:

--- a/controls/roles/manage-service/molecule/monitor-lighthouse/prepare.yml
+++ b/controls/roles/manage-service/molecule/monitor-lighthouse/prepare.yml
@@ -41,7 +41,7 @@
             state: started
             configuration:
               id: "{{ beacon_service }}"
-              image: sigp/lighthouse:v2.1.2
+              image: "sigp/lighthouse:{{ stereum.defaults.versions.lighthouse }}"
               env: {}
               ports:
                 - 0.0.0.0:9000:9000/tcp

--- a/controls/roles/manage-service/molecule/monitor-nimbus/converge.yml
+++ b/controls/roles/manage-service/molecule/monitor-nimbus/converge.yml
@@ -25,7 +25,7 @@
             state: started
             configuration:
               id: "{{ prometheus_service }}"
-              image: prom/prometheus:v2.33.1
+              image: "prom/prometheus:{{ stereum.defaults.versions.prometheus }}"
               ports:
                 - 127.0.0.1:9090:9090/tcp
               env:
@@ -73,7 +73,7 @@
             state: started
             configuration:
               id: "{{ prometheus_node_exporter_service }}"
-              image: prom/node-exporter:v1.3.1
+              image: "prom/node-exporter:{{ stereum.defaults.versions.node_exporter }}"
               ports: []
               env: {}
               command: []
@@ -94,7 +94,7 @@
             state: started
             configuration:
               id: "{{ grafana_service }}"
-              image: grafana/grafana:8.4.0
+              image: "grafana/grafana:{{ stereum.defaults.versions.grafana }}"
               ports:
                 - 127.0.0.1:3000:3000/tcp
               env:

--- a/controls/roles/manage-service/molecule/monitor-nimbus/prepare.yml
+++ b/controls/roles/manage-service/molecule/monitor-nimbus/prepare.yml
@@ -41,7 +41,7 @@
             state: started
             configuration:
               id: "{{ beacon_service }}"
-              image: statusim/nimbus-eth2:multiarch-v22.3.0
+              image: "statusim/nimbus-eth2:{{ stereum.defaults.versions.nimbus }}"
               ports:
                 - 0.0.0.0:9000:9000/tcp
                 - 0.0.0.0:9000:9000/udp

--- a/controls/roles/manage-service/molecule/monitor-prysm/converge.yml
+++ b/controls/roles/manage-service/molecule/monitor-prysm/converge.yml
@@ -25,7 +25,7 @@
             state: started
             configuration:
               id: "{{ prometheus_service }}"
-              image: prom/prometheus:v2.33.1
+              image: "prom/prometheus:{{ stereum.defaults.versions.prometheus }}"
               ports:
                 - 127.0.0.1:9090:9090/tcp
               env:
@@ -73,7 +73,7 @@
             state: started
             configuration:
               id: "{{ prometheus_node_exporter_service }}"
-              image: prom/node-exporter:v1.3.1
+              image: "prom/node-exporter:{{ stereum.defaults.versions.node_exporter }}"
               ports: []
               env: {}
               command: []
@@ -94,7 +94,7 @@
             state: started
             configuration:
               id: "{{ grafana_service }}"
-              image: grafana/grafana:8.4.0
+              image: "grafana/grafana:{{ stereum.defaults.versions.grafana }}"
               ports:
                 - 127.0.0.1:3000:3000/tcp
               env:

--- a/controls/roles/manage-service/molecule/monitor-prysm/prepare.yml
+++ b/controls/roles/manage-service/molecule/monitor-prysm/prepare.yml
@@ -41,7 +41,7 @@
             state: started
             configuration:
               id: "{{ beacon_service }}"
-              image: prysmaticlabs/prysm-beacon-chain:HEAD-c8a7f6-debug
+              image: "prysmaticlabs/prysm-beacon-chain:{{ stereum.defaults.versions.prysm }}"
               ports:
                 - 127.0.0.1:4000:4000/tcp
                 - 0.0.0.0:12000:12000/udp

--- a/controls/roles/manage-service/molecule/monitor-teku/converge.yml
+++ b/controls/roles/manage-service/molecule/monitor-teku/converge.yml
@@ -25,7 +25,7 @@
             state: started
             configuration:
               id: "{{ prometheus_service }}"
-              image: prom/prometheus:v2.33.1
+              image: "prom/prometheus:{{ stereum.defaults.versions.prometheus }}"
               ports:
                 - 127.0.0.1:9090:9090/tcp
               env:
@@ -73,7 +73,7 @@
             state: started
             configuration:
               id: "{{ prometheus_node_exporter_service }}"
-              image: prom/node-exporter:v1.3.1
+              image: "prom/node-exporter:{{ stereum.defaults.versions.node_exporter }}"
               ports: []
               env: {}
               command: []
@@ -94,7 +94,7 @@
             state: started
             configuration:
               id: "{{ grafana_service }}"
-              image: grafana/grafana:8.4.0
+              image: "grafana/grafana:{{ stereum.defaults.versions.grafana }}"
               ports:
                 - 127.0.0.1:3000:3000/tcp
               env:

--- a/controls/roles/manage-service/molecule/monitor-teku/prepare.yml
+++ b/controls/roles/manage-service/molecule/monitor-teku/prepare.yml
@@ -41,7 +41,7 @@
             state: started
             configuration:
               id: "{{ beacon_service }}"
-              image: consensys/teku:22.5.0
+              image: "consensys/teku:{{ stereum.defaults.versions.teku }}"
               ports:
                 - 0.0.0.0:9001:9001/tcp
                 - 0.0.0.0:9001:9001/udp

--- a/controls/roles/manage-service/molecule/ssv-lighthouse/converge.yml
+++ b/controls/roles/manage-service/molecule/ssv-lighthouse/converge.yml
@@ -22,7 +22,7 @@
             state: started
             configuration:
               id: "{{ ssv_service }}"
-              image: bloxstaking/ssv-node:v0.1.12
+              image: "bloxstaking/ssv-node:{{ stereum.defaults.versions.blox_ssv }}"
               ports:
                 - 0.0.0.0:12000:12000/udp
                 - 0.0.0.0:13000:13000/tcp

--- a/controls/roles/manage-service/molecule/ssv-lighthouse/prepare.yml
+++ b/controls/roles/manage-service/molecule/ssv-lighthouse/prepare.yml
@@ -81,7 +81,7 @@
             state: started
             configuration:
               id: "{{ beacon_service }}"
-              image: sigp/lighthouse:v2.1.2
+              image: "sigp/lighthouse:{{ stereum.defaults.versions.lighthouse }}"
               env: {}
               ports:
                 - 0.0.0.0:9000:9000/tcp

--- a/controls/roles/manage-service/molecule/ssv-nimbus/converge.yml
+++ b/controls/roles/manage-service/molecule/ssv-nimbus/converge.yml
@@ -22,7 +22,7 @@
             state: started
             configuration:
               id: "{{ ssv_service }}"
-              image: bloxstaking/ssv-node:v0.1.12
+              image: "bloxstaking/ssv-node:{{ stereum.defaults.versions.blox_ssv }}"
               ports:
                 - 0.0.0.0:12000:12000/udp
                 - 0.0.0.0:13000:13000/tcp

--- a/controls/roles/manage-service/molecule/ssv-nimbus/prepare.yml
+++ b/controls/roles/manage-service/molecule/ssv-nimbus/prepare.yml
@@ -82,7 +82,7 @@
             state: started
             configuration:
               id: "{{ beacon_service }}"
-              image: statusim/nimbus-eth2:multiarch-v22.3.0
+              image: "statusim/nimbus-eth2:{{ stereum.defaults.versions.nimbus }}"
               ports:
                 - 0.0.0.0:9000:9000/tcp
                 - 0.0.0.0:9000:9000/udp

--- a/controls/roles/manage-service/molecule/ssv-prysm/converge.yml
+++ b/controls/roles/manage-service/molecule/ssv-prysm/converge.yml
@@ -22,7 +22,7 @@
             state: started
             configuration:
               id: "{{ ssv_service }}"
-              image: bloxstaking/ssv-node:v0.1.12
+              image: "bloxstaking/ssv-node:{{ stereum.defaults.versions.blox_ssv }}"
               ports:
                 - 0.0.0.0:12000:12000/udp
                 - 0.0.0.0:13000:13000/tcp

--- a/controls/roles/manage-service/molecule/ssv-prysm/prepare.yml
+++ b/controls/roles/manage-service/molecule/ssv-prysm/prepare.yml
@@ -82,7 +82,7 @@
             state: started
             configuration:
               id: "{{ beacon_service }}"
-              image: gcr.io/prysmaticlabs/prysm/beacon-chain:v2.0.6
+              image: "prysmaticlabs/prysm-beacon-chain:{{ stereum.defaults.versions.prysm }}"
               ports:
                 - 127.0.0.1:4000:4000/tcp
                 - 0.0.0.0:12001:12001/udp

--- a/controls/roles/manage-service/molecule/ssv-teku/converge.yml
+++ b/controls/roles/manage-service/molecule/ssv-teku/converge.yml
@@ -22,7 +22,7 @@
             state: started
             configuration:
               id: "{{ ssv_service }}"
-              image: bloxstaking/ssv-node:v0.1.12
+              image: "bloxstaking/ssv-node:{{ stereum.defaults.versions.blox_ssv }}"
               ports:
                 - 0.0.0.0:12000:12000/udp
                 - 0.0.0.0:13000:13000/tcp

--- a/controls/roles/manage-service/molecule/ssv-teku/prepare.yml
+++ b/controls/roles/manage-service/molecule/ssv-teku/prepare.yml
@@ -82,7 +82,7 @@
             state: started
             configuration:
               id: "{{ beacon_service }}"
-              image: consensys/teku:21.12.2
+              image: "consensys/teku:{{ stereum.defaults.versions.teku }}"
               ports:
                 - 0.0.0.0:9001:9001/tcp
                 - 0.0.0.0:9001:9001/udp

--- a/controls/roles/manage-service/molecule/start-multiple/prepare.yml
+++ b/controls/roles/manage-service/molecule/start-multiple/prepare.yml
@@ -55,7 +55,7 @@
           entrypoint: []
           env: {}
           id: {{ beacon_service }}
-          image: sigp/lighthouse:v2.1.2
+          image: "sigp/lighthouse:{{ stereum.defaults.versions.lighthouse }}"
           ports:
             - 0.0.0.0:9000:9000/tcp
             - 0.0.0.0:9000:9000/udp
@@ -78,7 +78,7 @@
           env:
             STEREUM_DUMMY: foobar
           id: {{ geth_service }}
-          image: ethereum/client-go:v1.10.11
+          image: "ethereum/client-go:{{ stereum.defaults.versions.geth }}"
           name: geth
           ports:
           - 0.0.0.0:30303:30303/tcp

--- a/controls/roles/manage-service/molecule/start-stop/prepare.yml
+++ b/controls/roles/manage-service/molecule/start-stop/prepare.yml
@@ -51,7 +51,7 @@
           entrypoint: []
           env: {}
           id: {{ beacon_service }}
-          image: sigp/lighthouse:v2.1.2
+          image: "sigp/lighthouse:{{ stereum.defaults.versions.lighthouse }}"
           ports:
             - 0.0.0.0:9000:9000/tcp
             - 0.0.0.0:9000:9000/udp

--- a/controls/roles/manage-service/molecule/start/prepare.yml
+++ b/controls/roles/manage-service/molecule/start/prepare.yml
@@ -51,7 +51,7 @@
           entrypoint: []
           env: {}
           id: {{ beacon_service }}
-          image: sigp/lighthouse:v2.1.2
+          image: "sigp/lighthouse:{{ stereum.defaults.versions.lighthouse }}"
           ports:
             - 0.0.0.0:9000:9000/tcp
             - 0.0.0.0:9000:9000/udp

--- a/controls/roles/manage-service/molecule/write-start/converge.yml
+++ b/controls/roles/manage-service/molecule/write-start/converge.yml
@@ -12,7 +12,7 @@
         state: started
         configuration:
           id: "{{ beacon_service }}"
-          image: sigp/lighthouse:v2.1.2
+          image: "sigp/lighthouse:{{ stereum.defaults.versions.lighthouse }}"
           env: {}
           ports:
             - 0.0.0.0:9000:9000/tcp

--- a/controls/roles/ssv-key-generator/molecule/default/converge.yml
+++ b/controls/roles/ssv-key-generator/molecule/default/converge.yml
@@ -9,7 +9,7 @@
       env:
         CONFIG_PATH: /data/config.yaml
       id: {{ ssv_key_service }}
-      image: bloxstaking/ssv-node:alpine-dns
+      image: "bloxstaking/ssv-node:{{ stereum.defaults.versions.blox_ssv }}"
       ports:
       - 0.0.0.0:12000:12000/udp
       - 0.0.0.0:13000:13000/tcp


### PR DESCRIPTION
docker image versions are now managed centralized via `stereum.defaults.versions` 