### PR TITLE
ADD: prometheus automized config generation

### DIFF
--- a/controls/roles/manage-service/molecule/monitor-bloxssv/converge.yml
+++ b/controls/roles/manage-service/molecule/monitor-bloxssv/converge.yml
@@ -23,28 +23,13 @@
             save: true
             state: started
             configuration:
+              service: PrometheusService
               id: "{{ prometheus_service }}"
               image: "prom/prometheus:{{ stereum_static.defaults.versions.prometheus }}"
               ports:
                 - 127.0.0.1:9090:9090/tcp
-              env:
-                CONFIG: |
-                  global:
-                    scrape_interval:     15s
-                    evaluation_interval: 15s
-
-                  scrape_configs:
-                      - job_name: ssv
-                        metrics_path: /metrics
-                        static_configs:
-                          - targets: ['stereum-{{ ssv_service }}:15000']
-                      - job_name: ssv_health
-                        metrics_path: /health
-                        static_configs:
-                          - targets: ['stereum-{{ ssv_service }}:15000']
-              command: sh -c "touch /etc/prometheus/prometheus.yml &&
-                              echo \"$CONFIG\" > /etc/prometheus/prometheus.yml &&
-                              /bin/prometheus --config.file=/etc/prometheus/prometheus.yml"
+              env: {}
+              command: sh -c "/bin/prometheus --config.file=/etc/prometheus/prometheus.yml --web.enable-lifecycle"
               entrypoint: []
               user: "2000"
               volumes:
@@ -63,6 +48,7 @@
             save: true
             state: started
             configuration:
+              service: GrafanaService
               id: "{{ grafana_service }}"
               image: "grafana/grafana:{{ stereum_static.defaults.versions.grafana }}"
               ports:

--- a/controls/roles/manage-service/molecule/monitor-bloxssv/prepare.yml
+++ b/controls/roles/manage-service/molecule/monitor-bloxssv/prepare.yml
@@ -40,6 +40,7 @@
             save: true
             state: started
             configuration:
+              service: LighthouseBeaconService
               id: "{{ beacon_service }}"
               image: "sigp/lighthouse:{{ stereum_static.defaults.versions.lighthouse }}"
               env: {}
@@ -128,6 +129,7 @@
             save: true
             state: started
             configuration:
+              service: BloxSSVService
               id: "{{ ssv_service }}"
               image: "bloxstaking/ssv-node:{{ stereum_static.defaults.versions.blox_ssv }}"
               ports:

--- a/controls/roles/manage-service/molecule/monitor-bloxssv/verify.yml
+++ b/controls/roles/manage-service/molecule/monitor-bloxssv/verify.yml
@@ -51,7 +51,7 @@
     register: prometheus_up
     until:
       - prometheus_up.json.status == "success"
-      - prometheus_up.json.data.result | length > 0
+      - prometheus_up.json.data.result | length == 4
     retries: 10
     delay: 6
   # container's images & ports

--- a/controls/roles/manage-service/molecule/monitor-bloxssv/verify.yml
+++ b/controls/roles/manage-service/molecule/monitor-bloxssv/verify.yml
@@ -33,7 +33,7 @@
         - grafana_datasource.stat.exists
   - name: Waiting for the services to start properly
     pause:
-      minutes: 5
+      minutes: 1
   #  grafana logs
   - name: Grafana
     command: "docker logs --tail=100 stereum-0af126fa-c881-456f-9388-e977fb1537bf"

--- a/controls/roles/manage-service/molecule/monitor-geth/converge.yml
+++ b/controls/roles/manage-service/molecule/monitor-geth/converge.yml
@@ -23,24 +23,13 @@
             save: true
             state: started
             configuration:
+              service: PrometheusService
               id: "{{ prometheus_service }}"
               image: "prom/prometheus:{{ stereum_static.defaults.versions.prometheus }}"
               ports:
                 - 127.0.0.1:9090:9090/tcp
-              env:
-                CONFIG: |
-                  global:
-                    scrape_interval:     15s
-                    evaluation_interval: 15s
-
-                  scrape_configs:
-                    - job_name: 'stereum-{{ geth_service }}'
-                      metrics_path: /debug/metrics/prometheus
-                      static_configs:
-                        - targets: ['stereum-{{ geth_service }}:6060']
-              command: sh -c "touch /etc/prometheus/prometheus.yml &&
-                              echo \"$CONFIG\" > /etc/prometheus/prometheus.yml &&
-                              /bin/prometheus --config.file=/etc/prometheus/prometheus.yml"
+              env: {}
+              command: sh -c "/bin/prometheus --config.file=/etc/prometheus/prometheus.yml  --web.enable-lifecycle"
               entrypoint: []
               user: "2000"
               volumes:
@@ -59,6 +48,7 @@
             save: true
             state: started
             configuration:
+              service: GrafanaService
               id: "{{ grafana_service }}"
               image: "grafana/grafana:{{ stereum_static.defaults.versions.grafana }}"
               ports:

--- a/controls/roles/manage-service/molecule/monitor-geth/prepare.yml
+++ b/controls/roles/manage-service/molecule/monitor-geth/prepare.yml
@@ -39,6 +39,7 @@
             save: true
             state: started
             configuration:
+              service: GethService
               id: "{{ geth_service }}"
               image: "ethereum/client-go:{{ stereum_static.defaults.versions.geth }}"
               ports:

--- a/controls/roles/manage-service/molecule/monitor-geth/verify.yml
+++ b/controls/roles/manage-service/molecule/monitor-geth/verify.yml
@@ -33,7 +33,7 @@
         - grafana_datasource.stat.exists
   - name: Waiting for the services to start properly
     pause:
-      minutes: 5
+      minutes: 1
   #  grafana logs
   - name: Grafana
     command: "docker logs --tail=100 stereum-0af126fa-c881-456f-9388-e977fb1537bf"
@@ -51,7 +51,7 @@
     register: prometheus_up
     until:
       - prometheus_up.json.status == "success"
-      - prometheus_up.json.data.result | length > 0
+      - prometheus_up.json.data.result | length == 2
     retries: 10
     delay: 6
   # container's images & ports

--- a/controls/roles/manage-service/molecule/monitor-lighthouse/converge.yml
+++ b/controls/roles/manage-service/molecule/monitor-lighthouse/converge.yml
@@ -11,54 +11,6 @@
     grafana_provisioning: ["lighthouse"]
 
   tasks:
-    # prometheus service
-    - block:
-      - set_fact:
-          stereum: "{{ stereum_static | combine(stereum_args, recursive=True) }}"
-      - name: "Include manage-service"
-        include_role:
-          name: "manage-service"
-      vars:
-        stereum_args:
-          manage_service:
-            save: true
-            state: started
-            configuration:
-              id: "{{ prometheus_service }}"
-              image: "prom/prometheus:{{ stereum_static.defaults.versions.prometheus }}"
-              ports:
-                - 127.0.0.1:9090:9090/tcp
-              env:
-                CONFIG: |
-                  global:
-                    scrape_interval:     15s
-                    evaluation_interval: 15s
-
-                  alerting:
-                    alertmanagers:
-                    - static_configs:
-                      - targets:
-                        # - alertmanager:9093
-
-                  rule_files:
-                    # - "first_rules.yml"
-                    # - "second_rules.yml"
-
-                  scrape_configs:
-                    - job_name: 'stereum-{{ beacon_service }}'
-                      static_configs:
-                        - targets: ['stereum-{{ beacon_service }}:5054']
-                    - job_name: 'stereum-{{ prometheus_node_exporter_service }}'
-                      static_configs:
-                        - targets: ['stereum-{{ prometheus_node_exporter_service }}:9100']
-              command: sh -c "touch /etc/prometheus/prometheus.yml &&
-                              echo \"$CONFIG\" > /etc/prometheus/prometheus.yml &&
-                              /bin/prometheus --config.file=/etc/prometheus/prometheus.yml"
-              entrypoint: []
-              user: "2000"
-              volumes:
-                - "/opt/app/services/{{ prometheus_service }}/data/prometheus:/prometheus"
-                - "/opt/app/services/{{ prometheus_service }}/config:/etc/prometheus"
     # prometheus node-exporter service
     - block:
       - set_fact:
@@ -72,6 +24,7 @@
             save: true
             state: started
             configuration:
+              service: PrometheusNodeExporterService
               id: "{{ prometheus_node_exporter_service }}"
               image: "prom/node-exporter:{{ stereum_static.defaults.versions.node_exporter }}"
               ports: []
@@ -80,6 +33,31 @@
               entrypoint: ["/bin/node_exporter"]
               user: "2000"
               volumes: []
+    # prometheus service
+    - block:
+      - set_fact:
+          stereum: "{{ stereum_static | combine(stereum_args, recursive=True) }}"
+      - name: "Include manage-service"
+        include_role:
+          name: "manage-service"
+      vars:
+        stereum_args:
+          manage_service:
+            save: true
+            state: started
+            configuration:
+              service: PrometheusService
+              id: "{{ prometheus_service }}"
+              image: "prom/prometheus:{{ stereum_static.defaults.versions.prometheus }}"
+              ports:
+                - 127.0.0.1:9090:9090/tcp
+              env: {}
+              command: sh -c "/bin/prometheus --config.file=/etc/prometheus/prometheus.yml --web.enable-lifecycle"
+              entrypoint: []
+              user: "2000"
+              volumes:
+                - "/opt/app/services/{{ prometheus_service }}/data/prometheus:/prometheus"
+                - "/opt/app/services/{{ prometheus_service }}/config:/etc/prometheus"
     # grafana service
     - block:
       - set_fact:
@@ -93,6 +71,7 @@
             save: true
             state: started
             configuration:
+              service: GrafanaService
               id: "{{ grafana_service }}"
               image: "grafana/grafana:{{ stereum_static.defaults.versions.grafana }}"
               ports:

--- a/controls/roles/manage-service/molecule/monitor-lighthouse/prepare.yml
+++ b/controls/roles/manage-service/molecule/monitor-lighthouse/prepare.yml
@@ -40,6 +40,7 @@
             save: true
             state: started
             configuration:
+              service: LighthouseBeaconService
               id: "{{ beacon_service }}"
               image: "sigp/lighthouse:{{ stereum_static.defaults.versions.lighthouse }}"
               env: {}

--- a/controls/roles/manage-service/molecule/monitor-lighthouse/verify.yml
+++ b/controls/roles/manage-service/molecule/monitor-lighthouse/verify.yml
@@ -45,7 +45,7 @@
         - grafana_datasource.stat.exists
   - name: Waiting for the services to start properly
     pause:
-      minutes: 5
+      minutes: 1
   #  grafana logs
   - name: Grafana
     command: "docker logs --tail=100 stereum-59827650-8ac6-11ec-81ec-f3dc0fb8f30e"
@@ -56,33 +56,16 @@
       - grafana.stdout is not search("can't read dashboard provisioning files from directory")
     retries: 60
     delay: 10
-  #  prometheus logs
+  # prometheus
   - name: Prometheus
-    command: "docker logs --tail=100 stereum-4f260e42-8ac6-11ec-abba-4be6f5fee8db"
-    register: prometheus
+    uri:
+      url: http://localhost:9090/api/v1/query?query=up
+    register: prometheus_up
     until:
-      - prometheus.stderr is search("Server is ready to receive web requests")
-      - prometheus.stderr is not search("Error loading config")
-    retries: 60
-    delay: 10
-  #  node exporter logs
-  - name: Node exporter
-    command: "docker logs --tail=100 stereum-ef7d66cc-9022-11ec-8bd0-57e35985136a"
-    register: node_exporter
-    until:
-      - node_exporter.stderr is search("Listening on")
-    retries: 60
-    delay: 10
-  #  lighthouse beacon logs
-  - name: Lighthouse beacon
-    command: "docker logs --tail=200 stereum-cbf9f518-8ac7-11ec-8da2-ebc33b8d2c86"
-    register: lighthouse_beacon
-    until:
-      - lighthouse_beacon.stderr is search("est_time")
-      - lighthouse_beacon.stderr is not search("eth1-endpoints contains an invalid URL")
-      - lighthouse_beacon.stderr is not search("Error connecting to eth1 node endpoint")
-    retries: 60
-    delay: 10
+      - prometheus_up.json.status == "success"
+      - prometheus_up.json.data.result | length == 3
+    retries: 10
+    delay: 6
   # container's images & ports
   - shell: docker ps
     register: stereum_docker_ps

--- a/controls/roles/manage-service/molecule/monitor-nimbus/converge.yml
+++ b/controls/roles/manage-service/molecule/monitor-nimbus/converge.yml
@@ -11,55 +11,6 @@
     grafana_provisioning: ["nimbus"]
 
   tasks:
-    # prometheus service
-    - block:
-      - set_fact:
-          stereum: "{{ stereum_static | combine(stereum_args, recursive=True) }}"
-      - name: "Include manage-service"
-        include_role:
-          name: "manage-service"
-      vars:
-        stereum_args:
-          manage_service:
-            save: true
-            state: started
-            configuration:
-              id: "{{ prometheus_service }}"
-              image: "prom/prometheus:{{ stereum_static.defaults.versions.prometheus }}"
-              ports:
-                - 127.0.0.1:9090:9090/tcp
-              env:
-                CONFIG: |
-                  global:
-                    scrape_interval:     15s
-                    evaluation_interval: 15s
-
-                  alerting:
-                    alertmanagers:
-                    - static_configs:
-                      - targets:
-                        # - alertmanager:9093
-
-                  rule_files:
-                    # - "first_rules.yml"
-                    # - "second_rules.yml"
-
-                  scrape_configs:
-                    - job_name: 'stereum-{{ beacon_service }}'
-                      metrics_path: /metrics
-                      static_configs:
-                        - targets: ['stereum-{{ beacon_service }}:8008']
-                    - job_name: 'stereum-{{ prometheus_node_exporter_service }}'
-                      static_configs:
-                        - targets: ['stereum-{{ prometheus_node_exporter_service }}:9100']
-              command: sh -c "touch /etc/prometheus/prometheus.yml &&
-                              echo \"$CONFIG\" > /etc/prometheus/prometheus.yml &&
-                              /bin/prometheus --config.file=/etc/prometheus/prometheus.yml"
-              entrypoint: []
-              user: "2000"
-              volumes:
-                - "/opt/app/services/{{ prometheus_service }}/data/prometheus:/prometheus"
-                - "/opt/app/services/{{ prometheus_service }}/config:/etc/prometheus"
     # prometheus node-exporter service
     - block:
       - set_fact:
@@ -73,6 +24,7 @@
             save: true
             state: started
             configuration:
+              service: PrometheusNodeExporterService
               id: "{{ prometheus_node_exporter_service }}"
               image: "prom/node-exporter:{{ stereum_static.defaults.versions.node_exporter }}"
               ports: []
@@ -81,6 +33,31 @@
               entrypoint: ["/bin/node_exporter"]
               user: "2000"
               volumes: []
+    # prometheus service
+    - block:
+      - set_fact:
+          stereum: "{{ stereum_static | combine(stereum_args, recursive=True) }}"
+      - name: "Include manage-service"
+        include_role:
+          name: "manage-service"
+      vars:
+        stereum_args:
+          manage_service:
+            save: true
+            state: started
+            configuration:
+              service: PrometheusService
+              id: "{{ prometheus_service }}"
+              image: "prom/prometheus:{{ stereum_static.defaults.versions.prometheus }}"
+              ports:
+                - 127.0.0.1:9090:9090/tcp
+              env: {}
+              command: sh -c "/bin/prometheus --config.file=/etc/prometheus/prometheus.yml  --web.enable-lifecycle"
+              entrypoint: []
+              user: "2000"
+              volumes:
+                - "/opt/app/services/{{ prometheus_service }}/data/prometheus:/prometheus"
+                - "/opt/app/services/{{ prometheus_service }}/config:/etc/prometheus"
     # grafana service
     - block:
       - set_fact:
@@ -94,6 +71,7 @@
             save: true
             state: started
             configuration:
+              service: GrafanaService
               id: "{{ grafana_service }}"
               image: "grafana/grafana:{{ stereum_static.defaults.versions.grafana }}"
               ports:

--- a/controls/roles/manage-service/molecule/monitor-nimbus/prepare.yml
+++ b/controls/roles/manage-service/molecule/monitor-nimbus/prepare.yml
@@ -40,6 +40,7 @@
             save: true
             state: started
             configuration:
+              service: NimbusBeaconService
               id: "{{ beacon_service }}"
               image: "statusim/nimbus-eth2:{{ stereum_static.defaults.versions.nimbus }}"
               ports:

--- a/controls/roles/manage-service/molecule/monitor-nimbus/verify.yml
+++ b/controls/roles/manage-service/molecule/monitor-nimbus/verify.yml
@@ -43,9 +43,9 @@
         - grafana_dashboard.stat.exists
         - dashboard_yml.stat.exists
         - grafana_datasource.stat.exists
-  # - name: Waiting for the services to start properly
-  #   pause:
-  #     minutes: 5
+  - name: Waiting for the services to start properly
+    pause:
+      minutes: 1
   #  grafana logs
   - name: Grafana
     command: "docker logs --tail=100 stereum-52134fcc-9744-11ec-b5ca-572497326b43"
@@ -56,34 +56,16 @@
       - grafana.stdout is not search("can't read dashboard provisioning files from directory")
     retries: 60
     delay: 10
-  #  prometheus logs
+  # prometheus
   - name: Prometheus
-    command: "docker logs --tail=100  stereum-4a87cc9c-9744-11ec-a2ef-73b1b3e1ee0e"
-    register: prometheus
+    uri:
+      url: http://localhost:9090/api/v1/query?query=up
+    register: prometheus_up
     until:
-      - prometheus.stderr is search("Server is ready to receive web requests")
-      - prometheus.stderr is not search("Error loading config")
-    retries: 60
-    delay: 10
-  #  node exporter logs
-  - name: Node exporter
-    command: "docker logs --tail=100 stereum-77784ab0-9744-11ec-9726-ab848289b406"
-    register: node_exporter
-    until:
-      - node_exporter.stderr is search("Listening on")
-    retries: 60
-    delay: 10
-  #  nimbus beacon logs
-  - name: nimbus beacon
-    command: "docker logs --tail=200 stereum-5ac8408c-9744-11ec-8b66-0f11f6579737"
-    register: nimbus_beacon
-    until:
-      - nimbus_beacon.stdout is search('Slot start')
-      - nimbus_beacon.stdout is search('sync=')
-      - nimbus_beacon.stdout is not search('Eth1 chain monitoring failure')
-      - nimbus_beacon.stdout is not search('Failed to setup web3 connection')
-    retries: 60
-    delay: 10
+      - prometheus_up.json.status == "success"
+      - prometheus_up.json.data.result | length == 3
+    retries: 10
+    delay: 6
   # container's images & ports
   - shell: docker ps
     register: stereum_docker_ps

--- a/controls/roles/manage-service/molecule/monitor-prysm/converge.yml
+++ b/controls/roles/manage-service/molecule/monitor-prysm/converge.yml
@@ -11,54 +11,6 @@
     grafana_provisioning: ["prysm"]
 
   tasks:
-    # prometheus service
-    - block:
-      - set_fact:
-          stereum: "{{ stereum_static | combine(stereum_args, recursive=True) }}"
-      - name: "Include manage-service"
-        include_role:
-          name: "manage-service"
-      vars:
-        stereum_args:
-          manage_service:
-            save: true
-            state: started
-            configuration:
-              id: "{{ prometheus_service }}"
-              image: "prom/prometheus:{{ stereum_static.defaults.versions.prometheus }}"
-              ports:
-                - 127.0.0.1:9090:9090/tcp
-              env:
-                CONFIG: |
-                  global:
-                    scrape_interval:     15s
-                    evaluation_interval: 15s
-
-                  alerting:
-                    alertmanagers:
-                    - static_configs:
-                      - targets:
-                        # - alertmanager:9093
-
-                  rule_files:
-                    # - "first_rules.yml"
-                    # - "second_rules.yml"
-
-                  scrape_configs:
-                    - job_name: 'stereum-{{ beacon_service }}'
-                      static_configs:
-                        - targets: ['stereum-{{ beacon_service }}:8080']
-                    - job_name: 'stereum-{{ prometheus_node_exporter_service }}'
-                      static_configs:
-                        - targets: ['stereum-{{ prometheus_node_exporter_service }}:9100']
-              command: sh -c "touch /etc/prometheus/prometheus.yml &&
-                              echo \"$CONFIG\" > /etc/prometheus/prometheus.yml &&
-                              /bin/prometheus --config.file=/etc/prometheus/prometheus.yml"
-              entrypoint: []
-              user: "2000"
-              volumes:
-                - "/opt/app/services/{{ prometheus_service }}/data/prometheus:/prometheus"
-                - "/opt/app/services/{{ prometheus_service }}/config:/etc/prometheus"
     # prometheus node-exporter service
     - block:
       - set_fact:
@@ -72,6 +24,7 @@
             save: true
             state: started
             configuration:
+              service: PrometheusNodeExporterService
               id: "{{ prometheus_node_exporter_service }}"
               image: "prom/node-exporter:{{ stereum_static.defaults.versions.node_exporter }}"
               ports: []
@@ -80,6 +33,31 @@
               entrypoint: ["/bin/node_exporter"]
               user: "2000"
               volumes: []
+    # prometheus service
+    - block:
+      - set_fact:
+          stereum: "{{ stereum_static | combine(stereum_args, recursive=True) }}"
+      - name: "Include manage-service"
+        include_role:
+          name: "manage-service"
+      vars:
+        stereum_args:
+          manage_service:
+            save: true
+            state: started
+            configuration:
+              service: PrometheusService
+              id: "{{ prometheus_service }}"
+              image: "prom/prometheus:{{ stereum_static.defaults.versions.prometheus }}"
+              ports:
+                - 127.0.0.1:9090:9090/tcp
+              env: {}
+              command: sh -c "/bin/prometheus --config.file=/etc/prometheus/prometheus.yml --web.enable-lifecycle"
+              entrypoint: []
+              user: "2000"
+              volumes:
+                - "/opt/app/services/{{ prometheus_service }}/data/prometheus:/prometheus"
+                - "/opt/app/services/{{ prometheus_service }}/config:/etc/prometheus"
     # grafana service
     - block:
       - set_fact:
@@ -93,6 +71,7 @@
             save: true
             state: started
             configuration:
+              service: GrafanaService
               id: "{{ grafana_service }}"
               image: "grafana/grafana:{{ stereum_static.defaults.versions.grafana }}"
               ports:

--- a/controls/roles/manage-service/molecule/monitor-prysm/prepare.yml
+++ b/controls/roles/manage-service/molecule/monitor-prysm/prepare.yml
@@ -40,6 +40,7 @@
             save: true
             state: started
             configuration:
+              service: PrysmBeaconService
               id: "{{ beacon_service }}"
               image: "prysmaticlabs/prysm-beacon-chain:{{ stereum_static.defaults.versions.prysm }}"
               ports:

--- a/controls/roles/manage-service/molecule/monitor-prysm/verify.yml
+++ b/controls/roles/manage-service/molecule/monitor-prysm/verify.yml
@@ -45,7 +45,7 @@
         - grafana_datasource.stat.exists
   - name: Waiting for the services to start properly
     pause:
-      minutes: 5
+      minutes: 1
   #  grafana logs
   - name: Grafana
     command: "docker logs --tail=100 stereum-a5657b06-e068-11ec-8e1c-2f728e608caa"
@@ -56,32 +56,16 @@
       - grafana.stdout is not search("can't read dashboard provisioning files from directory")
     retries: 60
     delay: 10
-  #  prometheus logs
+  # prometheus
   - name: Prometheus
-    command: "docker logs --tail=100 stereum-87ca1aac-e068-11ec-a974-9bb31ed410be"
-    register: prometheus
+    uri:
+      url: http://localhost:9090/api/v1/query?query=up
+    register: prometheus_up
     until:
-      - prometheus.stderr is search("Server is ready to receive web requests")
-      - prometheus.stderr is not search("Error loading config")
-    retries: 60
-    delay: 10
-  #  node exporter logs
-  - name: Node exporter
-    command: "docker logs --tail=100 stereum-9da95c20-e068-11ec-b762-b38d94c6d8a8"
-    register: node_exporter
-    until:
-      - node_exporter.stderr is search("Listening on")
-    retries: 60
-    delay: 10
-  #  prysm beacon logs
-  - name: prysm beacon
-    command: "docker logs --tail=200 stereum-aba073ae-e068-11ec-8b8a-ab1197e06ccd"
-    register: prysm_beacon
-    until:
-      - prysm_beacon.stderr is search('estimated time remaining')
-      - prysm_beacon.stderr is not search('Could not connect to execution client endpoint')
-    retries: 60
-    delay: 10
+      - prometheus_up.json.status == "success"
+      - prometheus_up.json.data.result | length == 3
+    retries: 10
+    delay: 6
   # container's images & ports
   - shell: docker ps
     register: stereum_docker_ps

--- a/controls/roles/manage-service/molecule/monitor-teku/converge.yml
+++ b/controls/roles/manage-service/molecule/monitor-teku/converge.yml
@@ -11,57 +11,6 @@
     grafana_provisioning: ["teku"]
 
   tasks:
-    # prometheus service
-    - block:
-      - set_fact:
-          stereum: "{{ stereum_static | combine(stereum_args, recursive=True) }}"
-      - name: "Include manage-service"
-        include_role:
-          name: "manage-service"
-      vars:
-        stereum_args:
-          manage_service:
-            save: true
-            state: started
-            configuration:
-              id: "{{ prometheus_service }}"
-              image: "prom/prometheus:{{ stereum_static.defaults.versions.prometheus }}"
-              ports:
-                - 127.0.0.1:9090:9090/tcp
-              env:
-                CONFIG: |
-                  global:
-                    scrape_interval:     15s
-                    evaluation_interval: 15s
-
-                  alerting:
-                    alertmanagers:
-                    - static_configs:
-                      - targets:
-                        # - alertmanager:9093
-
-                  rule_files:
-                    # - "first_rules.yml"
-                    # - "second_rules.yml"
-
-                  scrape_configs:
-                    - job_name: 'stereum-{{ beacon_service }}'
-                      scrape_timeout: 10s
-                      metrics_path: /metrics
-                      scheme: http
-                      static_configs:
-                        - targets: ['stereum-{{ beacon_service }}:8008']
-                    - job_name: 'stereum-{{ prometheus_node_exporter_service }}'
-                      static_configs:
-                        - targets: ['stereum-{{ prometheus_node_exporter_service }}:9100']
-              command: sh -c "touch /etc/prometheus/prometheus.yml &&
-                              echo \"$CONFIG\" > /etc/prometheus/prometheus.yml &&
-                              /bin/prometheus --config.file=/etc/prometheus/prometheus.yml"
-              entrypoint: []
-              user: "2000"
-              volumes:
-                - "/opt/app/services/{{ prometheus_service }}/data/prometheus:/prometheus"
-                - "/opt/app/services/{{ prometheus_service }}/config:/etc/prometheus"
     # prometheus node-exporter service
     - block:
       - set_fact:
@@ -75,6 +24,7 @@
             save: true
             state: started
             configuration:
+              service: PrometheusNodeExporterService
               id: "{{ prometheus_node_exporter_service }}"
               image: "prom/node-exporter:{{ stereum_static.defaults.versions.node_exporter }}"
               ports: []
@@ -83,6 +33,31 @@
               entrypoint: ["/bin/node_exporter"]
               user: "2000"
               volumes: []
+    # prometheus service
+    - block:
+      - set_fact:
+          stereum: "{{ stereum_static | combine(stereum_args, recursive=True) }}"
+      - name: "Include manage-service"
+        include_role:
+          name: "manage-service"
+      vars:
+        stereum_args:
+          manage_service:
+            save: true
+            state: started
+            configuration:
+              service: PrometheusService
+              id: "{{ prometheus_service }}"
+              image: "prom/prometheus:{{ stereum_static.defaults.versions.prometheus }}"
+              ports:
+                - 127.0.0.1:9090:9090/tcp
+              env: {}
+              command: sh -c "/bin/prometheus --config.file=/etc/prometheus/prometheus.yml --web.enable-lifecycle"
+              entrypoint: []
+              user: "2000"
+              volumes:
+                - "/opt/app/services/{{ prometheus_service }}/data/prometheus:/prometheus"
+                - "/opt/app/services/{{ prometheus_service }}/config:/etc/prometheus"
     # grafana service
     - block:
       - set_fact:
@@ -96,6 +71,7 @@
             save: true
             state: started
             configuration:
+              service: GrafanaService
               id: "{{ grafana_service }}"
               image: "grafana/grafana:{{ stereum_static.defaults.versions.grafana }}"
               ports:

--- a/controls/roles/manage-service/molecule/monitor-teku/prepare.yml
+++ b/controls/roles/manage-service/molecule/monitor-teku/prepare.yml
@@ -40,6 +40,7 @@
             save: true
             state: started
             configuration:
+              service: TekuBeaconService
               id: "{{ beacon_service }}"
               image: "consensys/teku:{{ stereum_static.defaults.versions.teku }}"
               ports:

--- a/controls/roles/manage-service/molecule/monitor-teku/verify.yml
+++ b/controls/roles/manage-service/molecule/monitor-teku/verify.yml
@@ -45,7 +45,7 @@
         - grafana_datasource.stat.exists
   - name: Waiting for the services to start properly
     pause:
-      minutes: 5
+      minutes: 1
   #  grafana logs
   - name: Grafana
     command: "docker logs --tail=100 stereum-0ee5a0e8-e0d6-11ec-add4-3b3d662c25b1"
@@ -56,32 +56,16 @@
       - grafana.stdout is not search("can't read dashboard provisioning files from directory")
     retries: 60
     delay: 10
-  #  prometheus logs
+  # prometheus
   - name: Prometheus
-    command: "docker logs --tail=100  stereum-f52b6dcc-e0d5-11ec-8e8d-87f977a4cd88"
-    register: prometheus
+    uri:
+      url: http://localhost:9090/api/v1/query?query=up
+    register: prometheus_up
     until:
-      - prometheus.stderr is search("Server is ready to receive web requests")
-      - prometheus.stderr is not search("Error loading config")
-    retries: 60
-    delay: 10
-  #  node exporter logs
-  - name: Node exporter
-    command: "docker logs --tail=100 stereum-ffd332e6-e0d5-11ec-a82b-9b01f3fb02d7"
-    register: node_exporter
-    until:
-      - node_exporter.stderr is search("Listening on")
-    retries: 60
-    delay: 10
-  #  teku beacon logs
-  - name: teku beacon
-    command: "docker logs --tail=200 stereum-1929168e-e0d6-11ec-9183-97daacc21ea6"
-    register: teku_beacon
-    until:
-      - teku_beacon.stdout is search("Syncing")
-      - teku_beacon.stdout is not search("Eth1 service down")
-    retries: 60
-    delay: 10
+      - prometheus_up.json.status == "success"
+      - prometheus_up.json.data.result | length == 3
+    retries: 10
+    delay: 6
   # container's images & ports
   - shell: docker ps
     register: stereum_docker_ps

--- a/controls/roles/manage-service/tasks/main.yml
+++ b/controls/roles/manage-service/tasks/main.yml
@@ -74,7 +74,14 @@
     with_items: "{{ stereum_service_configuration.volumes }}"
 
   - include_tasks: write-grafana-configuration.yml
-    when: stereum_service_configuration.image is match("grafana/grafana:*")
+    when: >
+      stereum_service_configuration.image is match("grafana/grafana:*") and
+      (stereum.manage_service.state == "started" or stereum.manage_service.state == "restarted")
+
+  - include_tasks: write-prometheus-configuration.yml
+    when: >
+      stereum_service_configuration.image is match("prom/prometheus:*") and
+      (stereum.manage_service.state == "started" or stereum.manage_service.state == "restarted")
 
   - name: Start service
     community.docker.docker_container:
@@ -101,4 +108,20 @@
         max-size: "100m"
     become: yes
     when: stereum.manage_service.state == "started" or stereum.manage_service.state == "restarted"
+
+  - name: Reload config (prometheus only)
+    community.docker.docker_container:
+      command_handling: correct
+      name: "reload-prometheus"
+      user: "2000"
+      image: "curlimages/curl:{{ stereum_static.defaults.versions.curl }}"
+      detach: false
+      command: |
+        curl -X POST http://prometheus:9090/-/reload -s
+      networks:
+        - name: stereum
+    become: yes
+    when: >
+      stereum_service_configuration.image is match("prom/prometheus:*") and
+      (stereum.manage_service.state == "started" or stereum.manage_service.state == "restarted")
   when: stereum.manage_service.state is defined

--- a/controls/roles/manage-service/tasks/write-prometheus-configuration.yml
+++ b/controls/roles/manage-service/tasks/write-prometheus-configuration.yml
@@ -1,0 +1,22 @@
+---
+- name: Find service configs
+  find:
+    paths: "/etc/stereum/services"
+  register: service_config_files
+
+- name: Read all service configs
+  slurp:
+    src: "{{ item.path }}"
+  register: service_configs
+  with_items: "{{ service_config_files.files }}"
+
+- name: Write prometheus configuration
+  template:
+    src: prometheus.yml
+    dest: "{{ stereum_service_configuration.volumes | select('match', '.*\/etc\/prometheus') | first | split(':') | first }}/prometheus.yml"
+    owner: "2000"
+    group: "2000"
+    mode: 0644
+  become: yes
+
+# EOF

--- a/controls/roles/manage-service/templates/prometheus.yml
+++ b/controls/roles/manage-service/templates/prometheus.yml
@@ -1,0 +1,171 @@
+global:
+  scrape_interval:     15s
+  evaluation_interval: 15s
+
+scrape_configs:
+
+# besu
+  - job_name: besu
+    static_configs:
+      - targets: [
+{% set config_count = 0 %}
+{% for service_config in service_configs.results %}
+{%   if (service_config.content | b64decode | from_yaml).service == "BesuService" %}
+          {% if (config_count > 0) %},{% endif %}"stereum-{{ (service_config.content | b64decode | from_yaml).id }}:9545"
+          {% set config_count = config_count + 1 %}
+{%   endif %}
+{% endfor %}
+        ]
+
+# blox ssv
+  - job_name: ssv
+    metrics_path: /metrics
+    static_configs:
+      - targets: [
+{% set config_count = 0 %}
+{% for service_config in service_configs.results %}
+{%   if (service_config.content | b64decode | from_yaml).service == "BloxSSVService" %}
+          {% if (config_count > 0) %},{% endif %}"stereum-{{ (service_config.content | b64decode | from_yaml).id }}:15000"
+          {% set config_count = config_count + 1 %}
+{%   endif %}
+{% endfor %}
+        ]
+  - job_name: ssv_health
+    metrics_path: /health
+    static_configs:
+      - targets: [
+{% set config_count = 0 %}
+{% for service_config in service_configs.results %}
+{%   if (service_config.content | b64decode | from_yaml).service == "BloxSSVService" %}
+          {% if (config_count > 0) %},{% endif %}"stereum-{{ (service_config.content | b64decode | from_yaml).id }}:15000"
+          {% set config_count = config_count + 1 %}
+{%   endif %}
+{% endfor %}
+        ]
+
+# geth
+  - job_name: geth
+    metrics_path: /debug/metrics/prometheus
+    static_configs:
+      - targets: [
+{% set config_count = 0 %}
+{% for service_config in service_configs.results %}
+{%   if (service_config.content | b64decode | from_yaml).service == "GethService" %}
+          {% if (config_count > 0) %},{% endif %}"stereum-{{ (service_config.content | b64decode | from_yaml).id }}:6060"
+          {% set config_count = config_count + 1 %}
+{%   endif %}
+{% endfor %}
+        ]
+
+# lighthouse beacon
+  - job_name: lighthouse_beacon
+    static_configs:
+      - targets: [
+{% set config_count = 0 %}
+{% for service_config in service_configs.results %}
+{%   if (service_config.content | b64decode | from_yaml).service == "LighthouseBeaconService" %}
+          {% if (config_count > 0) %},{% endif %}"stereum-{{ (service_config.content | b64decode | from_yaml).id }}:5054"
+          {% set config_count = config_count + 1 %}
+{%   endif %}
+{% endfor %}
+        ]
+
+# lighthouse validator
+  - job_name: lighthouse_validator
+    static_configs:
+      - targets: [
+{% set config_count = 0 %}
+{% for service_config in service_configs.results %}
+{%   if (service_config.content | b64decode | from_yaml).service == "LighthouseValidatorService" %}
+          {% if (config_count > 0) %},{% endif %}"stereum-{{ (service_config.content | b64decode | from_yaml).id }}:5064"
+          {% set config_count = config_count + 1 %}
+{%   endif %}
+{% endfor %}
+        ]
+
+# nethermind
+  - job_name: nethermind
+    static_configs:
+      - targets: [
+{% set config_count = 0 %}
+{% for service_config in service_configs.results %}
+{%   if (service_config.content | b64decode | from_yaml).service == "NethermindService" %}
+          {% if (config_count > 0) %},{% endif %}"stereum-{{ (service_config.content | b64decode | from_yaml).id }}:6060"
+          {% set config_count = config_count + 1 %}
+{%   endif %}
+{% endfor %}
+        ]
+
+# nimbus consensus client
+  - job_name: nimbus
+    metrics_path: /metrics
+    static_configs:
+      - targets: [
+{% set config_count = 0 %}
+{% for service_config in service_configs.results %}
+{%   if (service_config.content | b64decode | from_yaml).service == "NimbusBeaconService" %}
+          {% if (config_count > 0) %},{% endif %}"stereum-{{ (service_config.content | b64decode | from_yaml).id }}:8008"
+          {% set config_count = config_count + 1 %}
+{%   endif %}
+{% endfor %}
+        ]
+
+# prometheus node exporter
+  - job_name: prometheus_node_exporter
+    static_configs:
+      - targets: [
+{% set config_count = 0 %}
+{% for service_config in service_configs.results %}
+{%   if (service_config.content | b64decode | from_yaml).service == "PrometheusNodeExporterService" %}
+          {% if (config_count > 0) %},{% endif %}"stereum-{{ (service_config.content | b64decode | from_yaml).id }}:9100"
+          {% set config_count = config_count + 1 %}
+{%   endif %}
+{% endfor %}
+        ]
+
+# prometheus
+  - job_name: prometheus
+    static_configs:
+      - targets: ["localhost:9090"]
+
+# prysm beacon
+  - job_name: prysm_beacon
+    static_configs:
+      - targets: [
+{% set config_count = 0 %}
+{% for service_config in service_configs.results %}
+{%   if (service_config.content | b64decode | from_yaml).service == "PrysmBeaconService" %}
+          {% if (config_count > 0) %},{% endif %}"stereum-{{ (service_config.content | b64decode | from_yaml).id }}:8080"
+          {% set config_count = config_count + 1 %}
+{%   endif %}
+{% endfor %}
+        ]
+
+# prysm validator
+  - job_name: prysm_validator
+    static_configs:
+      - targets: [
+{% set config_count = 0 %}
+{% for service_config in service_configs.results %}
+{%   if (service_config.content | b64decode | from_yaml).service == "PrysmValidatorService" %}
+          {% if (config_count > 0) %},{% endif %}"stereum-{{ (service_config.content | b64decode | from_yaml).id }}:8081"
+          {% set config_count = config_count + 1 %}
+{%   endif %}
+{% endfor %}
+        ]
+
+# teku
+  - job_name: teku
+    metrics_path: /metrics
+    static_configs:
+      - targets: [
+{% set config_count = 0 %}
+{% for service_config in service_configs.results %}
+{%   if (service_config.content | b64decode | from_yaml).service == "TekuBeaconService" %}
+          {% if (config_count > 0) %},{% endif %}"stereum-{{ (service_config.content | b64decode | from_yaml).id }}:8008"
+          {% set config_count = config_count + 1 %}
+{%   endif %}
+{% endfor %}
+        ]
+
+# EOF

--- a/launcher/src/backend/ethereum-services/PrometheusService.js
+++ b/launcher/src/backend/ethereum-services/PrometheusService.js
@@ -3,18 +3,12 @@ import { ServicePortDefinition } from './SerivcePortDefinition'
 import { ServiceVolume } from './ServiceVolume'
 
 export class PrometheusService extends NodeService {
-  static getServiceConfiguration (prometheusJobs) {
-    const jobs = prometheusJobs.map(service => service.buildPrometheusJob()).join('')
-    return { CONFIG: `global:\n  scrape_interval:     15s\n  evaluation_interval: 15s\n\nalerting:\n  alertmanagers:\n  - static_configs:\n    - targets:\n      # - alertmanager:9093\n\nrule_files:\n  # - \"first_rules.yml\"\n  # - \"second_rules.yml\"\n\nscrape_configs:${jobs}` }
-  }
-
   static buildByUserInput (network, ports, dir, prometheusJobs) {
     const service = new PrometheusService()
     service.setId()
     const workingDir = service.buildWorkingDir(dir)
-    
+
     const image = 'prom/prometheus'
-    const config = this.getServiceConfiguration(prometheusJobs)
 
     const dataDir = '/prometheus'
     const configDir = '/etc/prometheus'
@@ -30,9 +24,9 @@ export class PrometheusService extends NodeService {
       1, // configVersion
       image, // image
       'v2.36.2', // imageVersion
-      'sh -c "touch /etc/prometheus/prometheus.yml && echo \\"$CONFIG\\" > /etc/prometheus/prometheus.yml && /bin/prometheus --config.file=/etc/prometheus/prometheus.yml"', // command
+      'sh -c "/bin/prometheus --config.file=/etc/prometheus/prometheus.yml --web.enable-lifecycle"', // command
       null, // entrypoint
-      config, // env
+      null, // env
       ports, // ports
       volumes, // volumes
       null, // user

--- a/launcher/src/backend/ethereum-services/PrometheusService.test.js
+++ b/launcher/src/backend/ethereum-services/PrometheusService.test.js
@@ -2,27 +2,6 @@ import { PrometheusService } from './PrometheusService'
 import { networks } from './NodeService.js'
 import { ServicePort, servicePortProtocol } from './ServicePort.js'
 
-test('getServiceConfiguration', () => {
-  jest.mock('./NimbusBeaconService')
-  const NimbusBeaconService = require('./NimbusBeaconService')
-  NimbusBeaconService.NimbusBeaconService.mockImplementation(() => {
-    return {
-      buildPrometheusJob: jest.fn(() => { return `\n  - job_name: stereum-<serviceID>\n    metrics_path: /metrics\n    static_configs:\n      - targets: [stereum-<serviceID>:8008]` })
-    }
-  })
-
-  jest.mock('./PrometheusNodeExporterService')
-  const PrometheusNodeExporterService = require('./PrometheusNodeExporterService')
-  PrometheusNodeExporterService.PrometheusNodeExporterService.mockImplementation(() => {
-    return {
-      buildPrometheusJob: jest.fn(() => { return `\n  - job_name: stereum-<serviceID>\n    static_configs:\n      - targets: [stereum-<serviceID>:9100]` })
-    }
-  })
-
-  const config = PrometheusService.getServiceConfiguration([new NimbusBeaconService.NimbusBeaconService(), new PrometheusNodeExporterService.PrometheusNodeExporterService()])
-  expect(config).toStrictEqual({ CONFIG: 'global:\n  scrape_interval:     15s\n  evaluation_interval: 15s\n\nalerting:\n  alertmanagers:\n  - static_configs:\n    - targets:\n      # - alertmanager:9093\n\nrule_files:\n  # - \"first_rules.yml\"\n  # - \"second_rules.yml\"\n\nscrape_configs:\n  - job_name: stereum-<serviceID>\n    metrics_path: /metrics\n    static_configs:\n      - targets: [stereum-<serviceID>:8008]\n  - job_name: stereum-<serviceID>\n    static_configs:\n      - targets: [stereum-<serviceID>:9100]' })
-})
-
 test('buildConfiguration', () => {
   const ports = [
     new ServicePort('127.0.0.1', 9090, 9090, servicePortProtocol.tcp)
@@ -32,7 +11,6 @@ test('buildConfiguration', () => {
   const NimbusBeaconService = require('./NimbusBeaconService')
   NimbusBeaconService.NimbusBeaconService.mockImplementation(() => {
     return {
-      buildPrometheusJob: jest.fn(() => { return `\n  - job_name: stereum-<serviceID>\n    metrics_path: /metrics\n    static_configs:\n      - targets: [stereum-<serviceID>:8008]` }),
       buildMinimalConfiguration: jest.fn(() => {
         return {
           id: 'nimbus-id',
@@ -46,7 +24,6 @@ test('buildConfiguration', () => {
   const PrometheusNodeExporterService = require('./PrometheusNodeExporterService')
   PrometheusNodeExporterService.PrometheusNodeExporterService.mockImplementation(() => {
     return {
-      buildPrometheusJob: jest.fn(() => { return `\n  - job_name: stereum-<serviceID>\n    static_configs:\n      - targets: [stereum-<serviceID>:9100]` }),
       buildMinimalConfiguration: jest.fn(() => {
         return {
           id: 'pne-id',


### PR DESCRIPTION
resolves #433 

Please note:
- Prometheus needs to be kicked off to reload the config (done via task `Reload config (prometheus only)`)
- Prometheus looks into resolving automatic reload: https://github.com/prometheus/prometheus/issues/9783
- Prometheus needs a flag to allow reloading via HTTP: `--web.enable-lifecycle`
- All services configs need a `service` tag, otherwise prometheus won't start because the generation of the template fails