### PR TITLE
FIX: set default values when necessary on setup

### DIFF
--- a/controls/roles/setup/tasks/main.yml
+++ b/controls/roles/setup/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Apply stereum configuration to this setup
+  set_fact:
+    stereum: "{{ stereum_static }}"
+  when: stereum is undefined
+
 - include_tasks: update-os-ubuntu.yml
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 


### PR DESCRIPTION
fixing issue introduced with #492 

The default values (like installation path) are now set only when not already filled. `stereum` variable get's set by `controls/genericPlaybook.yaml` which is used by Stereum Launcher.