### PR TITLE
FIX: installing all packages at once

### DIFF
--- a/controls/roles/setup/tasks/docker-ubuntu.yaml
+++ b/controls/roles/setup/tasks/docker-ubuntu.yaml
@@ -1,29 +1,28 @@
 ---
 - name: Remove conflicting docker packages
   apt:
-    name: "{{ item }}"
-    state: absent
-  loop:
+    name:
     - docker-engine
     - docker.io
     - docker-registry
+    state: absent
 
 - name: Install required system packages
   apt:
-    name: "{{ item }}"
+    name:
+    - apt-transport-https
+    - ca-certificates
+    - curl
+    - software-properties-common
+    - python3-pip
+    - python3-docker
+    - virtualenv
+    - python3-setuptools
+    - gnupg2
+    - pass
+    - sysstat
     state: present
     update_cache: yes
-  loop:
-  - apt-transport-https
-  - ca-certificates
-  - curl
-  - software-properties-common
-  - python3-pip
-  - python3-docker
-  - virtualenv
-  - python3-setuptools
-  - gnupg2
-  - pass
 
 - name: Add Docker GPG apt Key
   apt_key:

--- a/controls/roles/ssv-key-generator/molecule/default/prepare.yml
+++ b/controls/roles/ssv-key-generator/molecule/default/prepare.yml
@@ -10,19 +10,15 @@
 
     - name: Remove conflicting docker packages
       apt:
-        name: "{{ item }}"
-        state: absent
-      loop:
+        name:
         - docker-engine
         - docker.io
         - docker-registry
+        state: absent
 
     - name: Install required system packages
       apt:
-        name: "{{ item }}"
-        state: present
-        update_cache: yes
-      loop:
+        name:
         - apt-transport-https
         - ca-certificates
         - curl
@@ -33,6 +29,8 @@
         - python3-setuptools
         - gnupg2
         - pass
+        state: present
+        update_cache: yes
 
     - name: Add Docker GPG apt Key
       apt_key:


### PR DESCRIPTION
Instead using a `loop:` which processes each package installation individually this PR makes `apt` installing all packages at once.

> When used with a loop: each package will be processed individually, it is much more efficient to pass the list directly to the name option.

Source: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/apt_module.html#notes