### PR TITLE
Fix molecule prysm verify

### DIFF
--- a/.github/workflows/test-molecule.yml
+++ b/.github/workflows/test-molecule.yml
@@ -41,7 +41,6 @@ jobs:
           {role: "validator-list-api", test: "nimbus", delay: 120},
           {role: "validator-list-api", test: "prysm", delay: 125},
           {role: "validator-list-api", test: "teku", delay: 130},
-          {role: "validator-fee-recipient-api", test: "teku", delay: 135},
           {role: "configure-updates", test: "default", delay: 1},
           {role: "configure-updates", test: "no-unattended-updates", delay: 1},
           {role: "setup", test: "default", delay: 1},

--- a/controls/roles/validator-import-api/molecule/prysm/verify.yml
+++ b/controls/roles/validator-import-api/molecule/prysm/verify.yml
@@ -1,6 +1,12 @@
 ---
 - name: Verify
   hosts: all
+  roles:
+    - role: '../'
+  vars_files:
+    - ../../../../defaults/stereum_defaults.yaml
+  vars:
+    validator_service: 0d4a2d58-b417-11ec-a0f3-0b91f10c3a8c
   gather_facts: false
   tasks:
   - stat: path=/etc/stereum/services
@@ -35,25 +41,7 @@
         - auth_token.stat.exists
   - name: Waiting for the services to start properly
     pause:
-      minutes: 3
-  # prysm beacon & validator logs
-  - name: prysm beacon node
-    command: "docker logs --tail=100 stereum-40a39644-b417-11ec-9917-3f1fbdf72a3a"
-    register: beacon
-    until:
-      - beacon.stderr is search('estimated time remaining')
-      - beacon.stderr is not search('Could not connect to execution endpoint')
-    retries: 360
-    delay: 10
-  - name: prysm validator
-    command: "docker logs --tail=70 stereum-0d4a2d58-b417-11ec-a0f3-0b91f10c3a8c"
-    register: validator
-    until:
-      - validator.stderr is search('Validating for public key')
-      - validator.stderr is search('Beacon chain started')
-      - validator.stderr is not search('Could not determine if beacon chain started')
-    retries: 360
-    delay: 10
+      minutes: 1
   # container's images & ports
   - shell: docker ps
     register: stereum_docker_ps
@@ -66,3 +54,16 @@
       - stereum_docker_ps.stdout.find("12000->12000") != -1
       - stereum_docker_ps.stdout.find("13000->13000") != -1
       - (stereum_docker_ps.stdout|regex_findall("Up")|length) == 2
+  # list keys
+  - name: "Include validator-list-api"
+    include_role:
+      name: "validator-list-api"
+  - debug:
+      msg: "{{ validator_list_api_result }}"
+  - assert:
+      that:
+      - validator_list_api_result.container.Output.find("acaa51756fb445b406c9e599f3f4bec991f7799c002619566ab1fa5b70445c62f1ac6561154ca5e49d7542dbe690b96b") > 0
+      - validator_list_api_result.container.Output.find("82ed748ffbc23ee3b730577a81f4cd05fe7dba234b3de5efc31f53de67091de9631d8581d72892351dfad52b65e53fbf") > 0
+      - validator_list_api_result.container.Output.find("948f092cb5b5cae121fdc14af0e4e5a90d03ab661266b700ded1c1ca4fd6f0a76f8dac187815409197bf036675571458") > 0
+
+# EOF

--- a/controls/roles/validator-list-api/molecule/prysm/verify.yml
+++ b/controls/roles/validator-list-api/molecule/prysm/verify.yml
@@ -1,6 +1,12 @@
 ---
 - name: Verify
   hosts: all
+  roles:
+    - role: '../'
+  vars_files:
+    - ../../../../defaults/stereum_defaults.yaml
+  vars:
+    validator_service: 076e91e2-e8bc-11ec-84c1-37b5fd5ea8e1
   gather_facts: false
   tasks:
   - stat: path=/etc/stereum/services
@@ -35,25 +41,7 @@
         - auth_token.stat.exists
   - name: Waiting for the services to start properly
     pause:
-      minutes: 3
-  # prysm beacon & validator logs
-  - name: prysm beacon node
-    command: "docker logs --tail=100 stereum-741e3504-e8bc-11ec-a681-5b761b6ebc01"
-    register: beacon
-    until:
-      - beacon.stderr is search('estimated time remaining')
-      - beacon.stderr is not search('Could not connect to execution endpoint')
-    retries: 360
-    delay: 10
-  - name: prysm validator
-    command: "docker logs --tail=70 stereum-076e91e2-e8bc-11ec-84c1-37b5fd5ea8e1"
-    register: validator
-    until:
-      - validator.stderr is search('Validating for public key')
-      - validator.stderr is search('Beacon chain started')
-      - validator.stderr is not search('Could not determine if beacon chain started')
-    retries: 360
-    delay: 10
+      minutes: 1
   # container's images & ports
   - shell: docker ps
     register: stereum_docker_ps
@@ -66,3 +54,15 @@
       - stereum_docker_ps.stdout.find("12000->12000") != -1
       - stereum_docker_ps.stdout.find("13000->13000") != -1
       - (stereum_docker_ps.stdout|regex_findall("Up")|length) == 2
+  # list keys
+  - name: "Include validator-list-api"
+    include_role:
+      name: "validator-list-api"
+  - debug:
+      msg: "{{ validator_list_api_result }}"
+  - assert:
+      that:
+      - validator_list_api_result.container.Output.find("82ed748ffbc23ee3b730577a81f4cd05fe7dba234b3de5efc31f53de67091de9631d8581d72892351dfad52b65e53fbf") > 0
+      - validator_list_api_result.container.Output.find("948f092cb5b5cae121fdc14af0e4e5a90d03ab661266b700ded1c1ca4fd6f0a76f8dac187815409197bf036675571458") > 0
+
+# EOF


### PR DESCRIPTION
- removing test for setting fee recipient for github actions only: doesn't work because of testnet implementation not ready yet.
- checking prysm not in logs but with api call, this way log can be full of unsynced-messages/-warnings and we still know if it's working or not