### PR TITLE
ADD: update-os & wiring with unattended update

### DIFF
--- a/controls/roles/configure-updates/tasks/main.yml
+++ b/controls/roles/configure-updates/tasks/main.yml
@@ -4,7 +4,7 @@
     name: "stereum auto unattended update"
     minute: "{{ 59 | random }}"
     hour: "{{ 5 | random }}" # execute updates only in the night time/very early morning
-    job: "cd \"{{ stereum.settings.controls_install_path | default(stereum.defaults.controls_install_path) }}\" && ./unattended-update.sh"
+    job: "cd \"{{ stereum.settings.controls_install_path | default(stereum.defaults.controls_install_path) }}/ansible/controls\" && ./unattended-update.sh"
     state: "{{ 'present' if (stereum.settings.updates.unattended.install | default(stereum.defaults.updates.unattended.install)) else 'absent' }}"
     user: "root"
   become: yes

--- a/controls/roles/update-os/.yamllint
+++ b/controls/roles/update-os/.yamllint
@@ -1,0 +1,33 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy: disable

--- a/controls/roles/update-os/molecule/default/converge.yml
+++ b/controls/roles/update-os/molecule/default/converge.yml
@@ -1,0 +1,15 @@
+---
+- name: Converge
+  hosts: all
+
+  tasks:
+    - set_fact:
+        stereum:
+          settings:
+            controls_install_path: "/opt/stereum"
+          only_os_updates: true
+    - debug:
+        msg: "{{ stereum }}"
+    - name: "Include update-os"
+      include_role:
+        name: "update-os"

--- a/controls/roles/update-os/molecule/default/create.yml
+++ b/controls/roles/update-os/molecule/default/create.yml
@@ -1,0 +1,86 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  vars:
+    ssh_port: 22
+    ssh_user: root
+    ssh_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/ssh_key"
+  tasks:
+    - name: Create SSH key
+      user:
+        name: "{{ lookup('env', 'USER') }}"
+        generate_ssh_key: true
+        ssh_key_file: "{{ ssh_path }}"
+        force: true
+      register: generated_ssh_key
+
+    - name: Register the SSH key name
+      set_fact:
+        ssh_key_name: "molecule-generated-{{ 12345 | random | to_uuid }}"
+
+    - name: Register SSH key for test instance(s)
+      hcloud_ssh_key:
+        name: "{{ ssh_key_name }}"
+        public_key: "{{ generated_ssh_key.ssh_public_key }}"
+        state: present
+
+    - name: Create molecule instance(s)
+      hcloud_server:
+        name: "{{ item.name }}"
+        server_type: "{{ item.server_type }}"
+        ssh_keys:
+          - "{{ ssh_key_name }}"
+        volumes: "{{ item.volumes | default(omit) }}"
+        image: "{{ item.image }}"
+        location: "hel1"
+        datacenter: "{{ item.datacenter | default(omit) }}"
+        user_data: "{{ item.user_data | default(omit) }}"
+        api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"
+        state: present
+      register: server
+      with_items: "{{ molecule_yml.platforms }}"
+      async: 7200
+      poll: 0
+
+    - name: Wait for instance(s) creation to complete
+      async_status:
+        jid: "{{ item.ansible_job_id }}"
+      register: hetzner_jobs
+      until: hetzner_jobs.finished
+      retries: 300
+      with_items: "{{ server.results }}"
+
+    - name: Populate instance config dict
+      set_fact:
+        instance_conf_dict: {
+          'instance': "{{ item.hcloud_server.name }}",
+          'ssh_key_name': "{{ ssh_key_name }}",
+          'address': "{{ item.hcloud_server.ipv4_address }}",
+          'user': "{{ ssh_user }}",
+          'port': "{{ ssh_port }}",
+          'identity_file': "{{ ssh_path }}", }
+      with_items: "{{ hetzner_jobs.results }}"
+      register: instance_config_dict
+      when: server.changed | bool
+
+    - name: Convert instance config dict to a list
+      set_fact:
+        instance_conf: "{{ instance_config_dict.results | map(attribute='ansible_facts.instance_conf_dict') | list }}"
+      when: server.changed | bool
+
+    - name: Dump instance config
+      copy:
+        content: "{{ instance_conf | to_json | from_json | to_yaml }}"
+        dest: "{{ molecule_instance_config }}"
+      when: server.changed | bool
+
+    - name: Wait for SSH
+      wait_for:
+        port: "{{ ssh_port }}"
+        host: "{{ item.address }}"
+        search_regex: SSH
+        delay: 10
+      with_items: "{{ lookup('file', molecule_instance_config) | from_yaml }}"

--- a/controls/roles/update-os/molecule/default/destroy.yml
+++ b/controls/roles/update-os/molecule/default/destroy.yml
@@ -1,0 +1,55 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  tasks:
+    - name: Populate the instance config
+      block:
+        - name: Populate instance config from file
+          set_fact:
+            instance_conf: "{{ lookup('file', molecule_instance_config) | from_yaml }}"
+            skip_instances: false
+      rescue:
+        - name: Populate instance config when file missing
+          set_fact:
+            instance_conf: {}
+            skip_instances: true
+
+    - name: Destroy molecule instance(s)
+      hcloud_server:
+        name: "{{ item.instance }}"
+        api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"
+        state: absent
+      register: server
+      with_items: "{{ instance_conf }}"
+      when: not skip_instances
+      async: 7200
+      poll: 0
+
+    - name: Wait for instance(s) deletion to complete
+      async_status:
+        jid: "{{ item.ansible_job_id }}"
+      register: hetzner_jobs
+      until: hetzner_jobs.finished
+      retries: 300
+      with_items: "{{ server.results }}"
+
+    - name: Remove registered SSH key
+      hcloud_ssh_key:
+        name: "{{ instance_conf[0].ssh_key_name }}"
+        state: absent
+      when:
+        - not skip_instances
+        - instance_conf | length  # must contain at least one instance
+
+    - name: Populate instance config
+      set_fact:
+        instance_conf: {}
+
+    - name: Dump instance config
+      copy:
+        content: "{{ instance_conf | to_yaml }}"
+        dest: "{{ molecule_instance_config }}"
+      when: server.changed | bool

--- a/controls/roles/update-os/molecule/default/molecule.yml
+++ b/controls/roles/update-os/molecule/default/molecule.yml
@@ -1,0 +1,28 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: hetznercloud
+platforms:
+  - name: "update-os--default--ubuntu-22.04"
+    server_type: cx11
+    image: ubuntu-22.04
+provisioner:
+  name: ansible
+  config_options:
+    ssh_connection:
+      ssh_args: -o ServerAliveInterval=30 -o ControlMaster=auto -o ControlPersist=60s
+lint: |
+  set -e
+  yamllint .
+  ansible-lint .
+scenario:
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    #- idempotence
+    - lint
+    - verify
+    - destroy

--- a/controls/roles/update-os/molecule/default/playbook.yml
+++ b/controls/roles/update-os/molecule/default/playbook.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: "Include update-os"
+      include_role:
+        name: "update-os"

--- a/controls/roles/update-os/molecule/default/prepare.yml
+++ b/controls/roles/update-os/molecule/default/prepare.yml
@@ -1,0 +1,50 @@
+---
+- name: Prepare
+  hosts: all
+  roles:
+    - role: '../'
+  vars_files:
+    - ../../../../defaults/stereum_defaults.yaml
+
+  tasks:
+    - name: Update cache & os (Ubuntu)
+      apt:
+        update_cache: yes
+        upgrade: dist
+      become: true
+      changed_when: false
+      when: ansible_distribution == "Ubuntu"
+    - name: Install python for Ansible (Ubuntu)
+      apt:
+        name: pip
+        state: present
+      become: true
+      changed_when: false
+      when: ansible_distribution == "Ubuntu"
+
+    - name: Install python for Ansible (CentOS 8)
+      raw: yum install -y python38 tar && yum remove -y python36
+      become: true
+      changed_when: false
+      when: ansible_distribution == "CentOS"
+
+    - name: Install p3-pip, expect (Ubuntu)
+      apt:
+        name:
+          - python3-pip
+          - expect
+          - git
+      become: true
+      when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+
+    - name: Install pip, expect (CentOS 8)
+      yum:
+        name:
+          - python3-pip
+          - expect
+          - git
+        state: latest
+      become: true
+      when: ansible_distribution == "CentOS"
+
+# EOF

--- a/controls/roles/update-os/molecule/default/verify.yml
+++ b/controls/roles/update-os/molecule/default/verify.yml
@@ -1,0 +1,24 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+
+  # wait for server to come back online
+  - pause:
+      seconds: 30
+
+  # check for updates
+  - name: list available updates
+    command: apt list --upgradable
+    register: os_update_list
+    become: yes
+  - debug:
+      msg: "{{ os_update_list }}"
+  - name: check os update
+    assert:
+      that:
+        - os_update_list.stdout_lines | length == 1
+        - os_update_list.stdout_lines[0] is match("Listing*")
+
+# EOF

--- a/controls/roles/update-os/molecule/run-stereum-service-update/converge.yml
+++ b/controls/roles/update-os/molecule/run-stereum-service-update/converge.yml
@@ -1,0 +1,14 @@
+---
+- name: Converge
+  hosts: all
+
+  tasks:
+    - set_fact:
+        stereum:
+          settings:
+            controls_install_path: "/opt/stereum"
+    - debug:
+        msg: "{{ stereum }}"
+    - name: "Include update-os"
+      include_role:
+        name: "update-os"

--- a/controls/roles/update-os/molecule/run-stereum-service-update/create.yml
+++ b/controls/roles/update-os/molecule/run-stereum-service-update/create.yml
@@ -1,0 +1,86 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  vars:
+    ssh_port: 22
+    ssh_user: root
+    ssh_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/ssh_key"
+  tasks:
+    - name: Create SSH key
+      user:
+        name: "{{ lookup('env', 'USER') }}"
+        generate_ssh_key: true
+        ssh_key_file: "{{ ssh_path }}"
+        force: true
+      register: generated_ssh_key
+
+    - name: Register the SSH key name
+      set_fact:
+        ssh_key_name: "molecule-generated-{{ 12345 | random | to_uuid }}"
+
+    - name: Register SSH key for test instance(s)
+      hcloud_ssh_key:
+        name: "{{ ssh_key_name }}"
+        public_key: "{{ generated_ssh_key.ssh_public_key }}"
+        state: present
+
+    - name: Create molecule instance(s)
+      hcloud_server:
+        name: "{{ item.name }}"
+        server_type: "{{ item.server_type }}"
+        ssh_keys:
+          - "{{ ssh_key_name }}"
+        volumes: "{{ item.volumes | default(omit) }}"
+        image: "{{ item.image }}"
+        location: "hel1"
+        datacenter: "{{ item.datacenter | default(omit) }}"
+        user_data: "{{ item.user_data | default(omit) }}"
+        api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"
+        state: present
+      register: server
+      with_items: "{{ molecule_yml.platforms }}"
+      async: 7200
+      poll: 0
+
+    - name: Wait for instance(s) creation to complete
+      async_status:
+        jid: "{{ item.ansible_job_id }}"
+      register: hetzner_jobs
+      until: hetzner_jobs.finished
+      retries: 300
+      with_items: "{{ server.results }}"
+
+    - name: Populate instance config dict
+      set_fact:
+        instance_conf_dict: {
+          'instance': "{{ item.hcloud_server.name }}",
+          'ssh_key_name': "{{ ssh_key_name }}",
+          'address': "{{ item.hcloud_server.ipv4_address }}",
+          'user': "{{ ssh_user }}",
+          'port': "{{ ssh_port }}",
+          'identity_file': "{{ ssh_path }}", }
+      with_items: "{{ hetzner_jobs.results }}"
+      register: instance_config_dict
+      when: server.changed | bool
+
+    - name: Convert instance config dict to a list
+      set_fact:
+        instance_conf: "{{ instance_config_dict.results | map(attribute='ansible_facts.instance_conf_dict') | list }}"
+      when: server.changed | bool
+
+    - name: Dump instance config
+      copy:
+        content: "{{ instance_conf | to_json | from_json | to_yaml }}"
+        dest: "{{ molecule_instance_config }}"
+      when: server.changed | bool
+
+    - name: Wait for SSH
+      wait_for:
+        port: "{{ ssh_port }}"
+        host: "{{ item.address }}"
+        search_regex: SSH
+        delay: 10
+      with_items: "{{ lookup('file', molecule_instance_config) | from_yaml }}"

--- a/controls/roles/update-os/molecule/run-stereum-service-update/destroy.yml
+++ b/controls/roles/update-os/molecule/run-stereum-service-update/destroy.yml
@@ -1,0 +1,55 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  tasks:
+    - name: Populate the instance config
+      block:
+        - name: Populate instance config from file
+          set_fact:
+            instance_conf: "{{ lookup('file', molecule_instance_config) | from_yaml }}"
+            skip_instances: false
+      rescue:
+        - name: Populate instance config when file missing
+          set_fact:
+            instance_conf: {}
+            skip_instances: true
+
+    - name: Destroy molecule instance(s)
+      hcloud_server:
+        name: "{{ item.instance }}"
+        api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"
+        state: absent
+      register: server
+      with_items: "{{ instance_conf }}"
+      when: not skip_instances
+      async: 7200
+      poll: 0
+
+    - name: Wait for instance(s) deletion to complete
+      async_status:
+        jid: "{{ item.ansible_job_id }}"
+      register: hetzner_jobs
+      until: hetzner_jobs.finished
+      retries: 300
+      with_items: "{{ server.results }}"
+
+    - name: Remove registered SSH key
+      hcloud_ssh_key:
+        name: "{{ instance_conf[0].ssh_key_name }}"
+        state: absent
+      when:
+        - not skip_instances
+        - instance_conf | length  # must contain at least one instance
+
+    - name: Populate instance config
+      set_fact:
+        instance_conf: {}
+
+    - name: Dump instance config
+      copy:
+        content: "{{ instance_conf | to_yaml }}"
+        dest: "{{ molecule_instance_config }}"
+      when: server.changed | bool

--- a/controls/roles/update-os/molecule/run-stereum-service-update/molecule.yml
+++ b/controls/roles/update-os/molecule/run-stereum-service-update/molecule.yml
@@ -1,0 +1,28 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: hetznercloud
+platforms:
+  - name: "update-os--run-stereum-service-update--ubuntu-22.04"
+    server_type: cx11
+    image: ubuntu-22.04
+provisioner:
+  name: ansible
+  config_options:
+    ssh_connection:
+      ssh_args: -o ServerAliveInterval=30 -o ControlMaster=auto -o ControlPersist=60s
+lint: |
+  set -e
+  yamllint .
+  ansible-lint .
+scenario:
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    #- idempotence
+    - lint
+    - verify
+    - destroy

--- a/controls/roles/update-os/molecule/run-stereum-service-update/playbook.yml
+++ b/controls/roles/update-os/molecule/run-stereum-service-update/playbook.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: "Include update-os"
+      include_role:
+        name: "update-os"

--- a/controls/roles/update-os/molecule/run-stereum-service-update/prepare.yml
+++ b/controls/roles/update-os/molecule/run-stereum-service-update/prepare.yml
@@ -1,0 +1,68 @@
+---
+- name: Prepare
+  hosts: all
+  roles:
+    - role: '../'
+  vars_files:
+    - ../../../../defaults/stereum_defaults.yaml
+
+  tasks:
+    - name: Update cache & os (Ubuntu)
+      apt:
+        update_cache: yes
+        upgrade: dist
+      become: true
+      changed_when: false
+      when: ansible_distribution == "Ubuntu"
+    - name: Install python for Ansible (Ubuntu)
+      apt:
+        name: pip
+        state: present
+      become: true
+      changed_when: false
+      when: ansible_distribution == "Ubuntu"
+
+    - name: Install python for Ansible (CentOS 8)
+      raw: yum install -y python38 tar && yum remove -y python36
+      become: true
+      changed_when: false
+      when: ansible_distribution == "CentOS"
+
+    - name: Install p3-pip, expect (Ubuntu)
+      apt:
+        name:
+          - python3-pip
+          - expect
+          - git
+      become: true
+      when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+
+    - name: Install pip, expect (CentOS 8)
+      yum:
+        name:
+          - python3-pip
+          - expect
+          - git
+        state: latest
+      become: true
+      when: ansible_distribution == "CentOS"
+
+    - name: dummy directories
+      file:
+        path: "/opt/stereum/ansible/controls/"
+        state: directory
+      become: yes
+
+    - name: dummy script for stereum-service-update
+      copy:
+        content: |
+          #!/bin/bash
+
+          mkdir /tmp/run-stereum-service-update
+        dest: "/opt/stereum/ansible/controls/stereum-services-update.sh"
+        owner: "root"
+        group: "root"
+        mode: 0755
+      become: true
+
+# EOF

--- a/controls/roles/update-os/molecule/run-stereum-service-update/verify.yml
+++ b/controls/roles/update-os/molecule/run-stereum-service-update/verify.yml
@@ -1,0 +1,29 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+
+  # wait for server to come back online
+  - pause:
+      seconds: 30
+
+  # check for updates
+  - name: list available updates
+    command: apt list --upgradable
+    register: os_update_list
+    become: yes
+  - stat: path=/tmp/run-stereum-service-update
+    register: stereum_dummy_dir
+  - debug:
+      msg: "{{ os_update_list }}"
+  - debug:
+      msg: "{{ stereum_dummy_dir }}"
+  - name: checks
+    assert:
+      that:
+        - os_update_list.stdout_lines | length == 1
+        - os_update_list.stdout_lines[0] is match("Listing*")
+        - stereum_dummy_dir.stat.exists
+
+# EOF

--- a/controls/roles/update-os/tasks/main.yml
+++ b/controls/roles/update-os/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+- name: Upgrade all apt packages
+  apt:
+    update_cache: yes
+    upgrade: dist
+  become: yes
+
+- name: Check if a reboot is needed for Debian and Ubuntu boxes
+  stat:
+    path: /var/run/reboot-required
+    get_md5: no
+  register: reboot_required_file
+  become: yes
+
+- name: Create cron @reboot to run unattended stereum update
+  cron:
+    name: "resume stereum-services-update"
+    special_time: reboot
+    job: "cd \"{{ stereum.settings.controls_install_path | default(stereum.defaults.controls_install_path) }}/ansible/controls\" && ./stereum-services-update.sh"
+  when: >
+    reboot_required_file.stat.exists and
+    (stereum.only_os_updates is not defined or not stereum.only_os_updates)
+  become: yes
+
+- name: Run unattended stereum update
+  shell: "cd \"{{ stereum.settings.controls_install_path | default(stereum.defaults.controls_install_path) }}/ansible/controls\" && ./stereum-services-update.sh"
+  when: >
+    not reboot_required_file.stat.exists and
+    (stereum.only_os_updates is not defined or not stereum.only_os_updates)
+  become: yes
+
+- name: Reboot the Debian or Ubuntu server
+  shell: sleep 10 && /sbin/shutdown -r now 'Rebooting to update system libs'
+  ignore_errors: yes
+  async: 60
+  poll: 0
+  when: reboot_required_file.stat.exists
+  become: yes
+
+# EOF

--- a/controls/roles/update-stereum/tasks/main.yml
+++ b/controls/roles/update-stereum/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Remove "resume stereum-services-update" from crontab
+  cron:
+    name: "resume stereum-services-update"
+    state: absent
+  become: yes
+
 - name: Download update metadata
   uri:
     url: https://stereum.net/downloads/updates.json

--- a/controls/stereum-services-update.sh
+++ b/controls/stereum-services-update.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if ansible-playbook -v genericPlaybook.yaml --extra-vars "stereum_role=update-stereum"; then
+  ansible-playbook -v finishUpdate.yaml
+  ansible-playbook -v genericPlaybook.yaml --extra-vars "stereum_role=update-services"
+fi
+
+# EOF

--- a/controls/unattended-update.sh
+++ b/controls/unattended-update.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-if ansible-playbook -v genericPlaybook.yaml --extra-vars "stereum_role=update-stereum"; then
-  ansible-playbook -v finishUpdate.yaml
-  ansible-playbook -v genericPlaybook.yaml --extra-vars "stereum_role=update-services"
-fi
+ansible-playbook -v genericPlaybook.yaml --extra-vars "stereum_role=update-os"
 
 # EOF


### PR DESCRIPTION
covers some parts of #552 
- update os
- reboot if necessary
- resume with stereum- & service-updates (after reboot or immediately)

technical documentation: https://github.com/stereum-dev/ethereum-node/wiki/Unattended-Updates#role-update-os