### PR TITLE
ADD: key import error handling

### DIFF
--- a/launcher/src/components/UI/node-manage/NodeConfiguration.vue
+++ b/launcher/src/components/UI/node-manage/NodeConfiguration.vue
@@ -71,6 +71,7 @@ import ControlService from "@/store/ControlService";
 import { useServices } from "@/store/services";
 import { useNodeManage } from "../../../store/nodeManage";
 import { useControlStore } from "../../../store/theControl";
+import { useStakingStore } from "../../../store/theStaking";
 export default {
   data() {
     return {
@@ -99,6 +100,9 @@ export default {
       ServerName: "ServerName",
       ipAddress: "ipAddress",
     }),
+    ...mapWritableState(useStakingStore, {
+      keys: "keys",
+    })
   },
   methods: {
     openModal() {
@@ -122,6 +126,7 @@ export default {
     },
     removeAllPlugins() {
       if (this.removeIsConfirmed) {
+        this.keys = []
         this.versions = {};
         this.headerServices = [];
         this.runningServices = [];

--- a/launcher/src/components/UI/the-staking/FinishModal.vue
+++ b/launcher/src/components/UI/the-staking/FinishModal.vue
@@ -1,0 +1,138 @@
+<template>
+  <div class="finish-modal-parent">
+    <div class="modal-opacity"></div>
+    <div class="finish-modal-content">
+      <div class="title-box">
+        <img src="../../../../public/img/icon/form-setup/warning.png" alt="" />
+      </div>
+      <div class="import-message">
+        <span>{{ message }}</span>
+      </div>
+      <div class="confirm-btn">
+        <div class="confirm-box" @click="$emit('hideModal')">
+          <span>Confirm</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+<script>
+export default {
+    props: ["message"],
+};
+</script>
+<style scoped>
+.finish-modal-parent {
+  width: 100%;
+  height: 100%;
+  position: fixed;
+  top: 10%;
+  left: 5%;
+  z-index: 310;
+}
+.modal-opacity {
+  width: 100%;
+  height: 100%;
+  background-color: black;
+  position: fixed;
+  left: 0;
+  top: 0;
+  opacity: 0.7;
+  z-index: 311;
+}
+.finish-modal-content {
+  width: 40%;
+  height: 40%;
+  border-radius: 1rem;
+  background-color: #324844;
+  border: 4px solid rgb(171, 170, 170);
+  z-index: 312;
+  opacity: 1;
+  position: fixed;
+  top: 30%;
+  left: 30%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  box-shadow: 1px 1px 5px 1px rgb(6, 6, 6);
+}
+.title-box {
+  width: 100%;
+  height: 50px;
+  margin-top: 10px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.title-box img {
+  width: 45px;
+  height: 45px;
+}
+.import-message {
+  width: 95%;
+  height: 40%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+}
+.import-message span:first-child {
+  color: rgb(124, 162, 197);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+.import-message span:last-child {
+  color: rgb(197, 197, 197);
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin-top: 20px;
+  text-align: center;
+}
+/* .import-message span {
+  color: rgb(195, 195, 195);
+  font-size: 1rem;
+  font-weight: 700;
+} */
+.confirm-btn {
+  width: 100%;
+  height: 30%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+.confirm-box {
+  width: 50%;
+  height: 45%;
+  border-radius: 10px;
+  border: 1px solid #8f8f8f;
+  background-color: #8f8f8f;
+  box-shadow: 0 1px 3px 1px rgb(35, 59, 53);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: rgb(210, 210, 210);
+  text-transform: uppercase;
+}
+
+.confirm-box:hover {
+  transform: scale(1.1);
+  transition-duration: 100ms;
+  border: 1px solid #4e0a0a;
+}
+.confirm-box:active {
+  transform: scale(1);
+  box-shadow: none;
+  transition-duration: 100ms;
+}
+.close {
+  color: rgb(154, 154, 154);
+  font-size: 0.55rem;
+  font-weight: 500;
+  align-self: center;
+}
+</style>

--- a/launcher/src/components/UI/the-staking/KeyTable.vue
+++ b/launcher/src/components/UI/the-staking/KeyTable.vue
@@ -10,6 +10,11 @@
           <span id="balance">BALANCE</span>
           <span id="option">OPTIONS</span>
         </div>
+        <finish-modal
+          v-if="bDialogVisible"
+          @hide-modal="hideBDialog"
+          :message="message"
+        ></finish-modal>
         <div
           class="table-content"
           v-if="insertFilePage"
@@ -168,20 +173,22 @@
   </div>
 </template>
 <script>
-import ShowKey from "./DropZone.vue";
-import DropZone from "./ShowKey.vue";
+import DropZone from "./DropZone.vue";
+import ShowKey from "./ShowKey.vue";
+import FinishModal from "./FinishModal.vue";
 import ControlService from "@/store/ControlService";
 import { mapWritableState } from "pinia";
 import { useServices } from "@/store/services";
 import { useStakingStore } from "@/store/theStaking";
 import axios from "axios";
 export default {
-  components: { ShowKey, DropZone },
+  components: { ShowKey, DropZone, FinishModal },
   data() {
     return {
+      message: "",
+      bDialogVisible: true,
       isDragOver: false,
       keyFiles: [],
-      keys: [],
       insertFilePage: true,
       enterPasswordPage: false,
       passwordInputActive: false,
@@ -213,6 +220,7 @@ export default {
     }),
     ...mapWritableState(useStakingStore, {
       totalBalance: "totalBalance",
+      keys: "",
     }),
   },
   methods: {
@@ -344,11 +352,13 @@ export default {
       }
     },
     importKey: async function () {
-      await ControlService.importKey({
+      this.message = await ControlService.importKey({
         files: this.keyFiles,
         password: this.password,
       });
+      this.bDialogVisible = true
       this.forceRefresh = true;
+      this.keyFiles = [];
       this.listKeys();
       this.password = "";
       this.insertFilePage = true;
@@ -357,7 +367,6 @@ export default {
     },
     uploadFileHandler(event) {
       let uploadedFiles = event.target.files;
-      console.log(uploadedFiles);
       if (
         !this.keyFiles.includes(uploadedFiles[0]["name"]) &&
         uploadedFiles[0]["type"] === "application/json"
@@ -396,6 +405,9 @@ export default {
         this.passwordInputActive = false;
       }
     },
+    hideBDialog() {
+      this.bDialogVisible = false
+    }
   },
 };
 </script>

--- a/launcher/src/store/theStaking.js
+++ b/launcher/src/store/theStaking.js
@@ -4,6 +4,7 @@ export const useStakingStore = defineStore("theStaking", {
   state: () => {
     return {
       totalBalance: 0,
+      keys: [],
     };
   },
   actions: {},


### PR DESCRIPTION
fixes #594 
fixes #593 
there is not a pop up that shows the status of the import:
when there is no error it says: "<number of keys> Keys were imported!"
if there is it prints the error

@maxbehzadi82 you may need to make some ui changes i just copied the delete modal from `FormSetup.vue` and changed it up a little bit 😅