### PR TITLE
FIX: remove fixed geth tests

### DIFF
--- a/controls/roles/manage-service/molecule/besu-lighthouse/create.yml
+++ b/controls/roles/manage-service/molecule/besu-lighthouse/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/besu-nimbus/create.yml
+++ b/controls/roles/manage-service/molecule/besu-nimbus/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/besu-prysm/create.yml
+++ b/controls/roles/manage-service/molecule/besu-prysm/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/besu-teku/create.yml
+++ b/controls/roles/manage-service/molecule/besu-teku/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/geth-lighthouse/create.yml
+++ b/controls/roles/manage-service/molecule/geth-lighthouse/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/geth-nimbus/create.yml
+++ b/controls/roles/manage-service/molecule/geth-nimbus/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/geth-prysm/create.yml
+++ b/controls/roles/manage-service/molecule/geth-prysm/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/geth-teku/create.yml
+++ b/controls/roles/manage-service/molecule/geth-teku/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/monitor-besu/create.yml
+++ b/controls/roles/manage-service/molecule/monitor-besu/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/monitor-geth/create.yml
+++ b/controls/roles/manage-service/molecule/monitor-geth/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/monitor-lighthouse/create.yml
+++ b/controls/roles/manage-service/molecule/monitor-lighthouse/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/monitor-nethermind/create.yml
+++ b/controls/roles/manage-service/molecule/monitor-nethermind/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/monitor-nimbus/create.yml
+++ b/controls/roles/manage-service/molecule/monitor-nimbus/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/monitor-prysm/create.yml
+++ b/controls/roles/manage-service/molecule/monitor-prysm/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/monitor-ssvnetwork/create.yml
+++ b/controls/roles/manage-service/molecule/monitor-ssvnetwork/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/monitor-teku/create.yml
+++ b/controls/roles/manage-service/molecule/monitor-teku/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/monitor-teku/molecule.yml
+++ b/controls/roles/manage-service/molecule/monitor-teku/molecule.yml
@@ -8,18 +8,10 @@ platforms:
     hostname: ubuntu
     server_type: cpx31
     image: ubuntu-22.04
-    network:
-      name: eth2-prater
-      ip_range: 10.10.0.0/24
-      ip: 10.10.0.133
 #  - name: "manage-service--monitor-teku--centos-stream-8"
 #    hostname: "centos"
 #    server_type: cpx31
 #    image: centos-stream-8
-#    network:
-#      name: eth2-prater
-#      ip_range: 10.10.0.0/24
-#      ip: 10.10.0.134
 provisioner:
   name: ansible
   config_options:

--- a/controls/roles/manage-service/molecule/monitor-teku/prepare.yml
+++ b/controls/roles/manage-service/molecule/monitor-teku/prepare.yml
@@ -49,7 +49,6 @@
               ports:
                 - 0.0.0.0:9001:9001/tcp
                 - 0.0.0.0:9001:9001/udp
-                - 127.0.0.1:5052:5052/tcp
               env:
                 JAVA_OPTS: -Xmx4g
               entrypoint: ["/opt/teku/bin/teku"]

--- a/controls/roles/manage-service/molecule/nethermind-lighthouse/create.yml
+++ b/controls/roles/manage-service/molecule/nethermind-lighthouse/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/nethermind-nimbus/create.yml
+++ b/controls/roles/manage-service/molecule/nethermind-nimbus/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/nethermind-prysm/create.yml
+++ b/controls/roles/manage-service/molecule/nethermind-prysm/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/nethermind-teku/create.yml
+++ b/controls/roles/manage-service/molecule/nethermind-teku/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/notifications/create.yml
+++ b/controls/roles/manage-service/molecule/notifications/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/ssv-lighthouse/create.yml
+++ b/controls/roles/manage-service/molecule/ssv-lighthouse/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/ssv-nimbus/create.yml
+++ b/controls/roles/manage-service/molecule/ssv-nimbus/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/start-multiple/create.yml
+++ b/controls/roles/manage-service/molecule/start-multiple/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/start-stop/create.yml
+++ b/controls/roles/manage-service/molecule/start-stop/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/start-stop/prepare.yml
+++ b/controls/roles/manage-service/molecule/start-stop/prepare.yml
@@ -39,8 +39,6 @@
             - bn
             - --debug-level=debug
             - --network=prater
-            - --eth1-endpoints=ws://10.10.0.2:8545
-            - --eth1-blocks-per-log-query=150
             - --datadir=/opt/app/beacon
             - --http
             - --http-address=0.0.0.0

--- a/controls/roles/manage-service/molecule/start/create.yml
+++ b/controls/roles/manage-service/molecule/start/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/start/prepare.yml
+++ b/controls/roles/manage-service/molecule/start/prepare.yml
@@ -39,8 +39,6 @@
             - bn
             - --debug-level=debug
             - --network=prater
-            - --eth1-endpoints=ws://10.10.0.2:8545
-            - --eth1-blocks-per-log-query=150
             - --datadir=/opt/app/beacon
             - --http
             - --http-address=0.0.0.0

--- a/controls/roles/manage-service/molecule/teku-geth/create.yml
+++ b/controls/roles/manage-service/molecule/teku-geth/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/manage-service/molecule/write-start/converge.yml
+++ b/controls/roles/manage-service/molecule/write-start/converge.yml
@@ -24,8 +24,6 @@
             - bn
             - --debug-level=debug
             - --network=prater
-            - --eth1-endpoints=ws://10.10.0.2:8545
-            - --eth1-blocks-per-log-query=150
             - --datadir=/opt/app/beacon
             - --http
             - --http-address=0.0.0.0

--- a/controls/roles/manage-service/molecule/write-start/create.yml
+++ b/controls/roles/manage-service/molecule/write-start/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/setup/molecule/default/create.yml
+++ b/controls/roles/setup/molecule/default/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/update-os/molecule/default/create.yml
+++ b/controls/roles/update-os/molecule/default/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/update-os/molecule/run-stereum-service-update/create.yml
+++ b/controls/roles/update-os/molecule/run-stereum-service-update/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/update-services/molecule/default/create.yml
+++ b/controls/roles/update-services/molecule/default/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/update-services/molecule/default/prepare.yml
+++ b/controls/roles/update-services/molecule/default/prepare.yml
@@ -41,8 +41,6 @@
             - bn
             - --debug-level=debug
             - --network=prater
-            - --eth1-endpoints=http://10.10.0.3:8545
-            - --eth1-blocks-per-log-query=150
             - --datadir=/opt/app/beacon
             - --http
             - --http-address=0.0.0.0

--- a/controls/roles/update-services/molecule/single-service/create.yml
+++ b/controls/roles/update-services/molecule/single-service/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/update-services/molecule/single-service/prepare.yml
+++ b/controls/roles/update-services/molecule/single-service/prepare.yml
@@ -41,8 +41,6 @@
             - bn
             - --debug-level=debug
             - --network=prater
-            - --eth1-endpoints=http://10.10.0.3:8545
-            - --eth1-blocks-per-log-query=150
             - --datadir=/opt/app/beacon
             - --http
             - --http-address=0.0.0.0

--- a/controls/roles/update-stereum/molecule/default/create.yml
+++ b/controls/roles/update-stereum/molecule/default/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/update-stereum/molecule/full/create.yml
+++ b/controls/roles/update-stereum/molecule/full/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/update-stereum/molecule/full/molecule.yml
+++ b/controls/roles/update-stereum/molecule/full/molecule.yml
@@ -7,17 +7,6 @@ platforms:
   - name: "update-stereum--full--ubuntu-2204"
     server_type: cpx21
     image: ubuntu-22.04
-    network:
-      name: eth2-prater
-      ip_range: 10.10.0.0/24
-      ip: 10.10.0.25
-  - name: "update-stereum--full--ubuntu-2004"
-    server_type: cpx21
-    image: ubuntu-20.04
-    network:
-      name: eth2-prater
-      ip_range: 10.10.0.0/24
-      ip: 10.10.0.26
 #  - name: "update-stereum--default--centos-stream-8"
 #    server_type: cx21
 #    image: centos-stream-8

--- a/controls/roles/update-stereum/molecule/full/prepare.yml
+++ b/controls/roles/update-stereum/molecule/full/prepare.yml
@@ -81,8 +81,6 @@
           - lighthouse
           - bn
           - --network=prater
-          - --eth1-endpoints=ws://10.10.0.2:8545
-          - --eth1-blocks-per-log-query=150
           - --datadir=/opt/app/beacon
           - --http
           - --http-address=0.0.0.0

--- a/controls/roles/update-stereum/molecule/override/create.yml
+++ b/controls/roles/update-stereum/molecule/override/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "hel1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/validator-delete-api/molecule/lighthouse/create.yml
+++ b/controls/roles/validator-delete-api/molecule/lighthouse/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "nbg1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/validator-delete-api/molecule/lighthouse/molecule.yml
+++ b/controls/roles/validator-delete-api/molecule/lighthouse/molecule.yml
@@ -8,18 +8,10 @@ platforms:
     hostname: ubuntu
     server_type: cpx21
     image: ubuntu-22.04
-    network:
-      name: eth2-prater
-      ip_range: 10.10.0.0/24
-      ip: 10.10.0.138
 #  - name: "validator-delete-api--lighthouse--centos-stream-8"
 #    hostname: "centos"
 #    server_type: cpx21
 #    image: centos-stream-8
-#    network:
-#      name: eth2-prater
-#      ip_range: 10.10.0.0/24
-#      ip: 10.10.0.139
 provisioner:
   name: ansible
   env:

--- a/controls/roles/validator-delete-api/molecule/lighthouse/prepare.yml
+++ b/controls/roles/validator-delete-api/molecule/lighthouse/prepare.yml
@@ -71,8 +71,6 @@
                 - bn
                 - --debug-level=debug
                 - --network=prater
-                - --eth1-endpoints=http://10.10.0.3:8545
-                - --eth1-blocks-per-log-query=150
                 - --datadir=/opt/app/beacon
                 - --http
                 - --http-address=0.0.0.0

--- a/controls/roles/validator-delete-api/molecule/nimbus/create.yml
+++ b/controls/roles/validator-delete-api/molecule/nimbus/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "nbg1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/validator-delete-api/molecule/nimbus/molecule.yml
+++ b/controls/roles/validator-delete-api/molecule/nimbus/molecule.yml
@@ -8,18 +8,10 @@ platforms:
     hostname: ubuntu
     server_type: cpx21
     image: ubuntu-22.04
-    network:
-      name: eth2-prater
-      ip_range: 10.10.0.0/24
-      ip: 10.10.0.143
 #  - name: "validator-delete-api--nimbus--centos-stream-8"
 #    hostname: "centos"
 #    server_type: cpx21
 #    image: centos-stream-8
-#    network:
-#      name: eth2-prater
-#      ip_range: 10.10.0.0/24
-#      ip: 10.10.0.144
 provisioner:
   name: ansible
   env:

--- a/controls/roles/validator-delete-api/molecule/nimbus/prepare.yml
+++ b/controls/roles/validator-delete-api/molecule/nimbus/prepare.yml
@@ -81,7 +81,6 @@
                 - --data-dir=/opt/app/beacon
                 - --validators-dir=/opt/app/validators
                 - --secrets-dir=/opt/app/secrets
-                - --web3-url=ws://10.10.0.2:8545
                 - --tcp-port=9000
                 - --udp-port=9000
                 - --rpc

--- a/controls/roles/validator-delete-api/molecule/prysm/create.yml
+++ b/controls/roles/validator-delete-api/molecule/prysm/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "nbg1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/validator-delete-api/molecule/prysm/molecule.yml
+++ b/controls/roles/validator-delete-api/molecule/prysm/molecule.yml
@@ -8,18 +8,10 @@ platforms:
     hostname: ubuntu
     server_type: cpx21
     image: ubuntu-22.04
-    network:
-      name: eth2-prater
-      ip_range: 10.10.0.0/24
-      ip: 10.10.0.148
 #  - name: "validator-delete-api--prysm--centos-stream-8"
 #    hostname: "centos"
 #    server_type: cpx21
 #    image: centos-stream-8
-#    network:
-#      name: eth2-prater
-#      ip_range: 10.10.0.0/24
-#      ip: 10.10.0.149
 provisioner:
   name: ansible
   config_options:

--- a/controls/roles/validator-delete-api/molecule/prysm/prepare.yml
+++ b/controls/roles/validator-delete-api/molecule/prysm/prepare.yml
@@ -80,7 +80,6 @@
                 --rpc-host=0.0.0.0
                 --grpc-gateway-host=0.0.0.0
                 --p2p-max-peers=100
-                --http-web3provider=http://10.10.0.3:8545
               user: "2000"
               volumes:
                 - "/opt/app/services/{{ beacon_service }}/prysm/beacon:/opt/app/beacon"

--- a/controls/roles/validator-delete-api/molecule/teku/create.yml
+++ b/controls/roles/validator-delete-api/molecule/teku/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "nbg1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/validator-delete-api/molecule/teku/molecule.yml
+++ b/controls/roles/validator-delete-api/molecule/teku/molecule.yml
@@ -8,18 +8,10 @@ platforms:
     hostname: ubuntu
     server_type: cpx21
     image: ubuntu-22.04
-    network:
-      name: eth2-prater
-      ip_range: 10.10.0.0/24
-      ip: 10.10.0.153
   # - name: "validator-delete-api--teku--centos-stream-8"
   #   hostname: "centos"
   #   server_type: cpx21
   #   image: centos-stream-8
-  #   network:
-  #     name: eth2-prater
-  #     ip_range: 10.10.0.0/24
-  #     ip: 10.10.0.154
 provisioner:
   name: ansible
   env:

--- a/controls/roles/validator-fee-recipient-api/molecule/teku/create.yml
+++ b/controls/roles/validator-fee-recipient-api/molecule/teku/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "fal1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/validator-fee-recipient-api/molecule/teku/molecule.yml
+++ b/controls/roles/validator-fee-recipient-api/molecule/teku/molecule.yml
@@ -8,18 +8,10 @@ platforms:
     hostname: ubuntu
     server_type: cpx21
     image: ubuntu-22.04
-    network:
-      name: eth2-prater
-      ip_range: 10.10.0.0/24
-      ip: 10.10.0.185
 #  - name: "validator-fee-recipient-api--teku--centos-stream-8"
 #    hostname: "centos"
 #    server_type: cpx21
 #    image: centos-stream-8
-#    network:
-#      name: eth2-prater
-#      ip_range: 10.10.0.0/24
-#      ip: 10.10.0.186
 provisioner:
   name: ansible
   env:

--- a/controls/roles/validator-import-api/molecule/lighthouse/create.yml
+++ b/controls/roles/validator-import-api/molecule/lighthouse/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "fal1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/validator-import-api/molecule/lighthouse/molecule.yml
+++ b/controls/roles/validator-import-api/molecule/lighthouse/molecule.yml
@@ -8,18 +8,10 @@ platforms:
     hostname: ubuntu
     server_type: cpx21
     image: ubuntu-22.04
-    network:
-      name: eth2-prater
-      ip_range: 10.10.0.0/24
-      ip: 10.10.0.136
 #  - name: "validator-import-api--lighthouse--centos-stream-8"
 #    hostname: "centos"
 #    server_type: cpx21
 #    image: centos-stream-8
-#    network:
-#      name: eth2-prater
-#      ip_range: 10.10.0.0/24
-#      ip: 10.10.0.137
 provisioner:
   name: ansible
   env:

--- a/controls/roles/validator-import-api/molecule/lighthouse/prepare.yml
+++ b/controls/roles/validator-import-api/molecule/lighthouse/prepare.yml
@@ -45,6 +45,7 @@
             save: true
             state: started
             configuration:
+              service: LighthouseBeaconService
               id: "{{ beacon_service }}"
               image: "sigp/lighthouse:{{ stereum_static.defaults.versions.lighthouse }}"
               env: {}
@@ -56,8 +57,6 @@
                 - bn
                 - --debug-level=debug
                 - --network=prater
-                - --eth1-endpoints=http://10.10.0.3:8545
-                - --eth1-blocks-per-log-query=150
                 - --datadir=/opt/app/beacon
                 - --http
                 - --http-address=0.0.0.0
@@ -83,7 +82,7 @@
           name: "manage-service"
       - name: Waiting for the services to start properly
         pause:
-          minutes: 5
+          seconds: 15
       vars:
         stereum_args:
           manage_service:

--- a/controls/roles/validator-import-api/molecule/lighthouse/verify.yml
+++ b/controls/roles/validator-import-api/molecule/lighthouse/verify.yml
@@ -25,18 +25,6 @@
     assert:
       that:
         - api_token.stat.exists
-  - name: Waiting for the services to start properly
-    pause:
-      minutes: 3
-  # lh beacon & validator logs
-  - name: Lighthouse beacon node
-    command: "docker logs --tail=150 stereum-7c0b52c4-98a3-11ec-85c7-0735587b56e3"
-    register: beacon
-    until:
-      - beacon.stderr is search('est_time')
-      - beacon.stderr is not search('Failed to start beacon node')
-    retries: 360
-    delay: 10
   - name: Lighthouse validator
     command: "docker logs --tail=150 stereum-0ca56612-998f-11ec-a28d-f71957ab65a0"
     register: validator

--- a/controls/roles/validator-import-api/molecule/nimbus/create.yml
+++ b/controls/roles/validator-import-api/molecule/nimbus/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "fal1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/validator-import-api/molecule/nimbus/molecule.yml
+++ b/controls/roles/validator-import-api/molecule/nimbus/molecule.yml
@@ -8,18 +8,10 @@ platforms:
     hostname: ubuntu
     server_type: cpx21
     image: ubuntu-22.04
-    network:
-      name: eth2-prater
-      ip_range: 10.10.0.0/24
-      ip: 10.10.0.141
 #  - name: "validator-import-api--nimbus--centos-stream-8"
 #    hostname: "centos"
 #    server_type: cpx21
 #    image: centos-stream-8
-#    network:
-#      name: eth2-prater
-#      ip_range: 10.10.0.0/24
-#      ip: 10.10.0.142
 provisioner:
   name: ansible
   env:

--- a/controls/roles/validator-import-api/molecule/nimbus/prepare.yml
+++ b/controls/roles/validator-import-api/molecule/nimbus/prepare.yml
@@ -56,7 +56,7 @@
         become: yes
       - name: Waiting for the services to start properly
         pause:
-          minutes: 5
+          seconds: 15
       vars:
         stereum_args:
           manage_service:
@@ -76,7 +76,6 @@
                 - --data-dir=/opt/app/beacon
                 - --validators-dir=/opt/app/validators
                 - --secrets-dir=/opt/app/secrets
-                - --web3-url=ws://10.10.0.2:8545
                 - --tcp-port=9000
                 - --udp-port=9000
                 - --rpc

--- a/controls/roles/validator-import-api/molecule/nimbus/verify.yml
+++ b/controls/roles/validator-import-api/molecule/nimbus/verify.yml
@@ -25,9 +25,6 @@
     assert:
       that:
         - api_token.stat.exists
-  - name: Waiting for the services to start properly
-    pause:
-      minutes: 3
   # Nimbus beacon & validator logs
   - name: Nimbus beacon & validator node
     command: "docker logs --tail=150 stereum-96d0bd64-b40b-11ec-9748-ef3d97c5f568"
@@ -37,8 +34,6 @@
       - beacon_validator.stdout is search('Slot start')
       - beacon_validator.stdout is search('Local validator attached')
       - beacon_validator.stdout is search('sync=')
-      - beacon_validator.stdout is not search('Eth1 chain monitoring failure')
-      - beacon_validator.stdout is not search('Failed to setup web3 connection')
     retries: 360
     delay: 10
   # container's images & ports

--- a/controls/roles/validator-import-api/molecule/prysm/create.yml
+++ b/controls/roles/validator-import-api/molecule/prysm/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "fal1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/validator-import-api/molecule/prysm/molecule.yml
+++ b/controls/roles/validator-import-api/molecule/prysm/molecule.yml
@@ -8,18 +8,10 @@ platforms:
     hostname: ubuntu
     server_type: cpx21
     image: ubuntu-22.04
-    network:
-      name: eth2-prater
-      ip_range: 10.10.0.0/24
-      ip: 10.10.0.146
 #  - name: "validator-import-api--prysm--centos-stream-8"
 #    hostname: "centos"
 #    server_type: cpx21
 #    image: centos-stream-8
-#    network:
-#      name: eth2-prater
-#      ip_range: 10.10.0.0/24
-#      ip: 10.10.0.147
 provisioner:
   name: ansible
   config_options:

--- a/controls/roles/validator-import-api/molecule/prysm/prepare.yml
+++ b/controls/roles/validator-import-api/molecule/prysm/prepare.yml
@@ -54,6 +54,7 @@
             save: true
             state: started
             configuration:
+              service: PrysmBeaconService
               id: "{{ beacon_service }}"
               image: "prysmaticlabs/prysm-beacon-chain:{{ stereum_static.defaults.versions.prysm }}"
               ports:
@@ -73,8 +74,6 @@
                 --genesis-state=/opt/app/genesis/prysm-prater-genesis.ssz
                 --rpc-host=0.0.0.0
                 --grpc-gateway-host=0.0.0.0
-                --p2p-max-peers=100
-                --http-web3provider=http://10.10.0.3:8545
               user: "2000"
               volumes:
                 - "/opt/app/services/{{ beacon_service }}/prysm/beacon:/opt/app/beacon"
@@ -134,9 +133,6 @@
         with_items:
           - "stereum-{{ beacon_service }}"
           - "stereum-{{ validator_service }}"
-      - name: Waiting for the services to start properly
-        pause:
-          minutes: 1
       vars:
         stereum_args:
           manage_service:

--- a/controls/roles/validator-import-api/molecule/prysm/verify.yml
+++ b/controls/roles/validator-import-api/molecule/prysm/verify.yml
@@ -39,9 +39,6 @@
     assert:
       that:
         - auth_token.stat.exists
-  - name: Waiting for the services to start properly
-    pause:
-      minutes: 1
   # container's images & ports
   - shell: docker ps
     register: stereum_docker_ps

--- a/controls/roles/validator-import-api/molecule/teku/create.yml
+++ b/controls/roles/validator-import-api/molecule/teku/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "fal1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/validator-import-api/molecule/teku/molecule.yml
+++ b/controls/roles/validator-import-api/molecule/teku/molecule.yml
@@ -8,18 +8,10 @@ platforms:
     hostname: ubuntu
     server_type: cpx31
     image: ubuntu-22.04
-    network:
-      name: eth2-prater
-      ip_range: 10.10.0.0/24
-      ip: 10.10.0.151
   # - name: "validator-import-api--teku--centos-stream-8"
   #   hostname: "centos"
   #   server_type: cpx21
   #   image: centos-stream-8
-  #   network:
-  #     name: eth2-prater
-  #     ip_range: 10.10.0.0/24
-  #     ip: 10.10.0.152
 provisioner:
   name: ansible
   env:

--- a/controls/roles/validator-import-api/molecule/teku/prepare.yml
+++ b/controls/roles/validator-import-api/molecule/teku/prepare.yml
@@ -6,6 +6,7 @@
   vars:
     consClient: "teku"
     beacon_service: c3d37b1a-b51b-11ec-849b-6375f2b3a630
+    geth_service: d6358d80-ea76-11ec-94b3-2fb45dfeb66a
 
   tasks:
     - name: Install pkgs for Ansible (Ubuntu)
@@ -47,6 +48,44 @@
 
     - include_role:
         name: "configure-firewall"
+
+    # geth service
+    - block:
+      - set_fact:
+          stereum: "{{ stereum_static | combine(stereum_args, recursive=True) }}"
+      - name: "Include manage-service"
+        include_role:
+          name: "manage-service"
+      vars:
+        stereum_args:
+          manage_service:
+            save: true
+            state: started
+            configuration:
+              service: GethService
+              id: "{{ geth_service }}"
+              image: "ethereum/client-go:{{ stereum_static.defaults.versions.geth }}"
+              ports:
+                - 0.0.0.0:30303:30303/tcp
+                - 0.0.0.0:30303:30303/udp
+              entrypoint: ["geth"]
+              env: {}
+              command:
+                - --goerli
+                - --http
+                - --datadir=/opt/app/geth
+                - --http.addr=0.0.0.0
+                - --http.vhosts=*
+                - --http.api="engine,eth,web3,net,debug"
+                - --http.corsdomain=*
+                - --authrpc.addr=0.0.0.0
+                - --authrpc.vhosts=*
+                - --authrpc.jwtsecret=/engine.jwt
+              user: "2000"
+              volumes:
+                - "/opt/app/services/{{ geth_service }}/data:/opt/app/geth"
+                - "/opt/app/services/{{ geth_service }}/engine.jwt:/engine.jwt"
+
 
     # teku beacon & validator service
     - block:
@@ -91,7 +130,7 @@
 
       - name: Waiting for the services to start properly
         pause:
-          minutes: 5
+          seconds: 15
 
       vars:
         stereum_args:
@@ -114,7 +153,7 @@
                 - --p2p-port=9001
                 - --validators-keystore-locking-enabled=false
                 - --validators-graffiti="stereum.net"
-                - --ee-endpoint=http://10.10.0.3:8545
+                - --ee-endpoint=http://stereum-{{ geth_service }}:8551
                 - --metrics-enabled=true
                 - --metrics-categories=BEACON,LIBP2P,NETWORK,PROCESS
                 - --metrics-port=8008
@@ -137,3 +176,4 @@
               user: "2000"
               volumes:
                 - "/opt/app/services/{{ beacon_service }}/data:/opt/app/data"
+                - "/opt/app/services/{{ geth_service }}/engine.jwt:/engine.jwt"

--- a/controls/roles/validator-import-api/molecule/teku/verify.yml
+++ b/controls/roles/validator-import-api/molecule/teku/verify.yml
@@ -30,16 +30,12 @@
         - teku_api_keystore.stat.exists
         - teku_api_password.stat.exists
         - validator_api_bearer.stat.exists
-  - name: Waiting for the services to start properly
-    pause:
-      minutes: 3
   # teku beacon & validator logs
   - name: teku beacon & validator node
     command: "docker logs --tail=150 stereum-c3d37b1a-b51b-11ec-849b-6375f2b3a630"
     register: beacon
     until:
       - beacon.stdout is search('Syncing')
-      - beacon.stdout is not search('Eth1 service down')
       - (beacon.stdout | regex_search("Loading \b(?:[1-9]|[1-9][0-9]{1,3})\b validator keys\.\.\.") ) != -1
       - (beacon.stdout | regex_search("Loading \b[0]+\b validator keys\.\.\.") ) != 1
     retries: 360
@@ -53,4 +49,4 @@
       that:
       - stereum_docker_ps.stdout.find("consensys/teku") != -1
       - stereum_docker_ps.stdout.find("9001->9001") != -1
-      - (stereum_docker_ps.stdout|regex_findall("Up")|length) == 1
+      - (stereum_docker_ps.stdout|regex_findall("Up")|length) == 2

--- a/controls/roles/validator-list-api/molecule/lighthouse/create.yml
+++ b/controls/roles/validator-list-api/molecule/lighthouse/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "nbg1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/validator-list-api/molecule/lighthouse/molecule.yml
+++ b/controls/roles/validator-list-api/molecule/lighthouse/molecule.yml
@@ -8,10 +8,6 @@ platforms:
     hostname: ubuntu
     server_type: cpx21
     image: ubuntu-22.04
-    network:
-      name: eth2-prater
-      ip_range: 10.10.0.0/24
-      ip: 10.10.0.156
 provisioner:
   name: ansible
   env:

--- a/controls/roles/validator-list-api/molecule/lighthouse/prepare.yml
+++ b/controls/roles/validator-list-api/molecule/lighthouse/prepare.yml
@@ -65,8 +65,6 @@
                 - bn
                 - --debug-level=debug
                 - --network=prater
-                - --eth1-endpoints=http://10.10.0.3:8545
-                - --eth1-blocks-per-log-query=150
                 - --datadir=/opt/app/beacon
                 - --http
                 - --http-address=0.0.0.0

--- a/controls/roles/validator-list-api/molecule/nimbus/create.yml
+++ b/controls/roles/validator-list-api/molecule/nimbus/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "nbg1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/validator-list-api/molecule/nimbus/molecule.yml
+++ b/controls/roles/validator-list-api/molecule/nimbus/molecule.yml
@@ -8,10 +8,6 @@ platforms:
     hostname: ubuntu
     server_type: cpx21
     image: ubuntu-22.04
-    network:
-      name: eth2-prater
-      ip_range: 10.10.0.0/24
-      ip: 10.10.0.157
 provisioner:
   name: ansible
   env:

--- a/controls/roles/validator-list-api/molecule/nimbus/prepare.yml
+++ b/controls/roles/validator-list-api/molecule/nimbus/prepare.yml
@@ -75,7 +75,6 @@
                 - --data-dir=/opt/app/beacon
                 - --validators-dir=/opt/app/validators
                 - --secrets-dir=/opt/app/secrets
-                - --web3-url=ws://10.10.0.2:8545
                 - --tcp-port=9000
                 - --udp-port=9000
                 - --rpc

--- a/controls/roles/validator-list-api/molecule/prysm/create.yml
+++ b/controls/roles/validator-list-api/molecule/prysm/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "nbg1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/validator-list-api/molecule/prysm/molecule.yml
+++ b/controls/roles/validator-list-api/molecule/prysm/molecule.yml
@@ -8,10 +8,6 @@ platforms:
     hostname: ubuntu
     server_type: cpx21
     image: ubuntu-22.04
-    network:
-      name: eth2-prater
-      ip_range: 10.10.0.0/24
-      ip: 10.10.0.158
 provisioner:
   name: ansible
   config_options:

--- a/controls/roles/validator-list-api/molecule/prysm/prepare.yml
+++ b/controls/roles/validator-list-api/molecule/prysm/prepare.yml
@@ -74,7 +74,6 @@
                 --rpc-host=0.0.0.0
                 --grpc-gateway-host=0.0.0.0
                 --p2p-max-peers=100
-                --http-web3provider=http://10.10.0.3:8545
               user: "2000"
               volumes:
                 - "/opt/app/services/{{ beacon_service }}/prysm/beacon:/opt/app/beacon"

--- a/controls/roles/validator-list-api/molecule/teku/create.yml
+++ b/controls/roles/validator-list-api/molecule/teku/create.yml
@@ -35,7 +35,6 @@
           - "{{ ssh_key_name }}"
         volumes: "{{ item.volumes | default(omit) }}"
         image: "{{ item.image }}"
-        location: "nbg1"
         datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         api_token: "{{ lookup('env', 'HCLOUD_TOKEN') }}"

--- a/controls/roles/validator-list-api/molecule/teku/molecule.yml
+++ b/controls/roles/validator-list-api/molecule/teku/molecule.yml
@@ -8,10 +8,6 @@ platforms:
     hostname: ubuntu
     server_type: cpx21
     image: ubuntu-22.04
-    network:
-      name: eth2-prater
-      ip_range: 10.10.0.0/24
-      ip: 10.10.0.159
 provisioner:
   name: ansible
   env:


### PR DESCRIPTION
Because it's not possible anymore to run a remote geth (jwt token required) this PR removes all dependencies to remote geth servers.