### PR TITLE
FIX: hide update button/icon if no update avail

### DIFF
--- a/launcher/src/components/UI/node-header/MainNavbar.vue
+++ b/launcher/src/components/UI/node-header/MainNavbar.vue
@@ -209,6 +209,7 @@ export default {
             name: "Stereum",
             version: response.stereum[response.stereum.length - 1].name,
             current: currentVersion ? currentVersion.name : "-",
+            current_commit: currentVersion ? currentVersion.commit : "-",
           };
 
           console.log("Stereum Update Available!");

--- a/launcher/src/components/UI/node-header/UpdatePanel.vue
+++ b/launcher/src/components/UI/node-header/UpdatePanel.vue
@@ -35,7 +35,7 @@
             <div class="searchBtn">
               <img src="/img/icon/header-icons/search.png" alt="icon" />
             </div>
-            <div class="downloadBtn" @click="$emit('runUpdate', stereumUpdate)">
+            <div  v-if="checkStereumUpdate()" class="downloadBtn" @click="$emit('runUpdate', stereumUpdate)">
               <img
                 src="/img/icon/node-journal-icons/download2.png"
                 alt="icon"
@@ -43,6 +43,7 @@
             </div>
 
             <div v-if="checkStereumUpdate()" class="available">
+
               <div class="updateIcon">
                 <img src="/img/icon/header-icons/update-green.png" alt="icon" />
               </div>
@@ -145,7 +146,9 @@ export default {
   methods: {
     checkStereumUpdate() {
       if (this.stereumUpdate && this.stereumUpdate.version) {
-        return true;
+        //console.log(this.stereumUpdate.commit)  // commit hash of the newest newest release tag
+        //console.log(this.stereumUpdate.current_commit)  // current installed commit on the os
+        return this.stereumUpdate.commit != this.stereumUpdate.current_commit ? true : false;
       }
       return false;
     },


### PR DESCRIPTION
does hide the update button and the icon below (inside update panel) if no new update is available