### PR TITLE
FIX: correct sudo permissions and logline argument

### DIFF
--- a/launcher/src/backend/SSHService.js
+++ b/launcher/src/backend/SSHService.js
@@ -76,13 +76,13 @@ export class SSHService {
     })
   }
 
-  async exec (command) {
-    return this.exec(command, command)
+  async exec (command, logline = null) {
+    logline = logline === null ? command : logline;
+    return this.execLogline(command, logline)
   }
 
-  async exec (command, logline) {
+  async execLogline (command, logline) {
     const ensureSudoCommand = "sudo -u 'root' -i <<'=====EOF'\n" + command + "\n=====EOF"
-
     return this.execCommand(ensureSudoCommand, logline)
   }
 

--- a/launcher/src/background.js
+++ b/launcher/src/background.js
@@ -123,6 +123,10 @@ promiseIpc.on("checkOS", async () => {
   return nodeConnection.os;
 });
 
+promiseIpc.on("checkSudo", async () => {
+  return await nodeConnection.checkSudo();
+});
+
 promiseIpc.on("getOneClickConstellation", async (arg) => {
   return await oneClickInstall.getSetupConstellation(arg.setup, arg.network);
 });

--- a/launcher/src/components/layers/InstallitionMenu.vue
+++ b/launcher/src/components/layers/InstallitionMenu.vue
@@ -19,7 +19,7 @@
         </div>
       </div> -->
     </div>
-    <div class="item-container">
+    <div class="item-container" >
       <div
         class="item-column"
         v-for="(install, index) in installation"
@@ -27,7 +27,7 @@
       >
         <router-link
           class="lintTtl"
-          :class="{ disabled: !install.display }"
+          :class="{ disabled: !install.display || !isSupported }"
           :to="install.path"
           ><button-installation
             onmousedown="return false"
@@ -81,7 +81,7 @@ export default {
     setTimeout(() => {
       this.active = false;
     }, 5000);
-    this.checkOS();
+    this.checkOsRequirements();
     this.randomValue();
   },
   computed: {
@@ -91,28 +91,65 @@ export default {
     randomValue() {
       this.value = Math.random() * this.max;
     },
-    display: async function (response) {
-      const data = await response;
-      if (data == "Ubuntu" || data == "CentOS") {
-        this.message = data.toUpperCase() + " IS A SUPPORTED OS";
-        this.isSupported = true;
-      } else if (data.name !== undefined) {
+    display: async function (osResponse, suResponse) {
+      const osData = await osResponse;
+      const suData = await suResponse;
+      if (osData == "Ubuntu" || osData == "CentOS") {
+        this.message = osData.toUpperCase() + " IS A SUPPORTED OS";
+        if (suData.rc) {
+          // Description of return codes (suData.rc):
+          // 1 = FAIL: user can not sudo at all because not in sudo group!
+          // 2 = FAIL: user can not sudo without password!
+          // 3 = ERROR: Executed code failed due to interactive syntax error
+          // There could also be unknown return codes that may happen on the OS!
+          // Those are usually 127 but they could also overwrite the "known" codes
+          // mentioned above. Therefore it's a good idea to parse stdout value in
+          // addition to the return code.
+          let errnum = parseInt(suData.rc);
+          let errmsg = suData.stdout.toLowerCase();
+          if(errnum === 1 && errmsg.indexOf("not in sudo group")){
+            // User needs to added in the group sudo AND the sudoers file with "%<username> ALL = (ALL) NOPASSWD: ALL"
+            this.message += " BUT YOUR USER HAS NO (PASSLESS) SUDO PERMISSION";
+          }else if(errnum === 2 && errmsg.indexOf("can not sudo without password")){
+            // User needs to added in the sudoers file with "%<username> ALL = (ALL) NOPASSWD: ALL"
+            this.message += " BUT YOU NEED TO ENABLE PASSLESS SUDO";
+          }else if(errnum === 3 && errmsg.indexOf("interactive syntax error")){
+            // We could not check due to interactive syntax error - allow install but show a warning
+            this.message += " BUT MAKE SURE TO ENABLE PASSLESS SUDO (" + errnum + ")";
+            this.isSupported = true;
+          }else{
+            // We could not check due to unknonw error - allow install but show a warning
+            this.message += " BUT MAKE SURE TO ENABLE PASSLESS SUDO (" + errnum + ")";
+            this.isSupported = true;
+          }
+        }else{
+          // OS supported, passless sudo avail - allow install :)
+          this.isSupported = true;
+        }
+      } else if (osData && osData.hasOwnProperty("name") && osData.name !== undefined) {
         this.message =
-          data.name.toUpperCase() + ": " + data.message.toUpperCase();
+          osData.name.toUpperCase() + ": " + osData.message.toUpperCase(); 
       } else {
         this.message = "UNSUPPORTED OS";
       }
       this.running = false;
     },
-    checkOS: async function () {
-      const response = ControlService.checkOS()
+    checkOsRequirements: async function () {
+      const osResponse = ControlService.checkOS()
         .then((result) => {
           return result;
         })
         .catch((error) => {
           return error;
         });
-      this.display(await response);
+      const suResponse = ControlService.checkSudo()
+        .then((result) => {
+          return result;
+        })
+        .catch((error) => {
+          return error;
+        });
+      this.display(await osResponse, await suResponse);
     },
   },
 };

--- a/launcher/src/store/ControlService.js
+++ b/launcher/src/store/ControlService.js
@@ -70,6 +70,10 @@ class ControlService extends EventEmitter {
     return await this.promiseIpc.send("checkOS");
   }
 
+  async checkSudo() {
+    return await this.promiseIpc.send("checkSudo");
+  }
+
   async getOneClickConstellation(args) {
     return await this.promiseIpc.send("getOneClickConstellation", args);
   }


### PR DESCRIPTION
Notify the user and prevent installation/login if sudo permissions are missing. (fixes #655)
Emulate method overloading for logline argument.

