### PR TITLE
FIX: failing test because of not set env

### DIFF
--- a/launcher/src/backend/NodeConnection.js
+++ b/launcher/src/backend/NodeConnection.js
@@ -6,7 +6,7 @@ import axios from "axios";
 import net from "net";
 import YAML from "yaml";
 const log = require("electron-log");
-if (process.env.IS_DEV === "true") {
+if (process.env.IS_DEV === "true" || process.env.NODE_ENV === "test") {
   global.branch = "main";
   log.info("pulling from main branch");
 } else {

--- a/launcher/src/backend/SSHService.js
+++ b/launcher/src/backend/SSHService.js
@@ -36,7 +36,7 @@ export class SSHService {
       //only works for ubuntu 22.04
       this.conn.on('banner', (msg) => {
         if(new RegExp(/^(?=.*\bchange\b)(?=.*\bpassword\b).*$/gm).test(msg.toLowerCase())){
-          if (process.env.IS_DEV === "true") {
+          if (process.env.NODE_ENV === "test") {
             resolve(this.conn)
           }
           reject(msg)
@@ -45,7 +45,7 @@ export class SSHService {
       this.conn.on('ready', async () => {
         let test = await this.exec('ls')
         if(new RegExp(/^(?=.*\bchange\b)(?=.*\bpassword\b).*$/gm).test(test.stderr.toLowerCase())){
-          if (process.env.IS_DEV === "true") {
+          if (process.env.NODE_ENV === "test") {
             resolve(this.conn)
           }
           reject(test.stderr)


### PR DESCRIPTION
Previously Jests Integration tests needed to be run with an env variable (`IS_DEV=true`).
Now the tests can be run without any envs (except HCLOUD_TOKEN).