### PR TITLE
ADD: change graffiti

### DIFF
--- a/controls/roles/manage-service/molecule/monitor-teku/verify.yml
+++ b/controls/roles/manage-service/molecule/monitor-teku/verify.yml
@@ -15,8 +15,6 @@
   - assert:
       that:
       - stereum_ufw_status.stdout.find("9001/tcp") != -1
-      - stereum_ufw_status.stdout.find("9001/udp") != -1
-      - stereum_ufw_status.stdout.find("5052/tcp") != -1
       - stereum_ufw_status.stdout.find("9090/tcp") != -1
       - stereum_ufw_status.stdout.find("3000/tcp") != -1
   # grafana config files

--- a/controls/roles/manage-service/tasks/main.yml
+++ b/controls/roles/manage-service/tasks/main.yml
@@ -100,6 +100,11 @@
       - stereum_service_configuration.service in ['BesuService', 'GethService', 'NethermindService', 'LighthouseBeaconService', 'NimbusBeaconService', 'PrysmBeaconService', 'TekuBeaconService']
       - stereum_service_configuration.volumes | select('search', ':/engine.jwt') | length > 0
 
+  - include_tasks: write-graffiti-files.yml
+    when: >
+      stereum_service_configuration.volumes | select('search', '/graffitis') | length > 0 and
+      (stereum.manage_service.state == "started" or stereum.manage_service.state == "restarted")
+
   - include_tasks: write-grafana-configuration.yml
     when: >
       stereum_service_configuration.image is match("grafana/grafana:*") and

--- a/controls/roles/manage-service/tasks/write-graffiti-files.yml
+++ b/controls/roles/manage-service/tasks/write-graffiti-files.yml
@@ -8,9 +8,12 @@
 - name: Lighthouse - Create Graffiti File
   copy:
     content: |
-      default: {{default_graffiti}}
+      default: {{ default_graffiti }}
     dest: "{{ graffiti_path }}"
     force: no
+    owner: "2000"
+    group: "2000"
+    mode: 0644
   when:
     service == "LighthouseValidatorService"
 
@@ -20,6 +23,9 @@
       default: "{{ default_graffiti }}"
     dest: "{{ graffiti_path }}"
     force: no
+    owner: "2000"
+    group: "2000"
+    mode: 0644
   when:
     service == "PrysmValidatorService"
 
@@ -29,4 +35,7 @@
       {{ default_graffiti }}
     dest: "{{ graffiti_path }}"
     force: no
+    owner: "2000"
+    group: "2000"
+    mode: 0644
   when: service == "TekuBeaconService"

--- a/controls/roles/manage-service/tasks/write-graffiti-files.yml
+++ b/controls/roles/manage-service/tasks/write-graffiti-files.yml
@@ -1,0 +1,32 @@
+---
+- name: Set Variables
+  set_fact:
+    service: "{{ stereum_service_configuration.service }}"
+    graffiti_path: "{{ stereum_service_configuration.volumes | select('search', '/graffitis') | first | split(':') | first }}/graffitis.yaml"
+    default_graffiti: "stereum.net"
+
+- name: Lighthouse - Create Graffiti File
+  copy:
+    content: |
+      default: {{default_graffiti}}
+    dest: "{{ graffiti_path }}"
+    force: no
+  when:
+    service == "LighthouseValidatorService"
+
+- name: Prysm - Create Graffiti File
+  copy:
+    content: |
+      default: "{{ default_graffiti }}"
+    dest: "{{ graffiti_path }}"
+    force: no
+  when:
+    service == "PrysmValidatorService"
+
+- name: Teku - Create Graffiti File
+  copy:
+    content: |
+      {{ default_graffiti }}
+    dest: "{{ graffiti_path }}"
+    force: no
+  when: service == "TekuBeaconService"

--- a/controls/roles/validator-delete-api/molecule/lighthouse/prepare.yml
+++ b/controls/roles/validator-delete-api/molecule/lighthouse/prepare.yml
@@ -60,6 +60,7 @@
             save: true
             state: started
             configuration:
+              service: LighthouseBeaconService
               id: "{{ beacon_service }}"
               image: "sigp/lighthouse:{{ stereum_static.defaults.versions.lighthouse }}"
               env: {}
@@ -115,7 +116,7 @@
                 - --beacon-nodes=http://stereum-{{ beacon_service }}:5052
                 - --datadir=/opt/app/validator
                 - --init-slashing-protection
-                - --graffiti="stereum.net"
+                - --graffiti-file=/opt/app/graffitis/graffitis.yaml
                 - --metrics
                 - --metrics-address=0.0.0.0
                 - --http
@@ -125,6 +126,7 @@
               user: "2000"
               volumes:
                 - "/opt/app/services/{{ validator_service }}/validator:/opt/app/validator"
+                - "/opt/app/services/{{ validator_service }}/graffitis:/opt/app/graffitis"
 
     - include_role:
         name: "validator-import-api"

--- a/controls/roles/validator-delete-api/molecule/lighthouse/verify.yml
+++ b/controls/roles/validator-delete-api/molecule/lighthouse/verify.yml
@@ -16,6 +16,14 @@
       that:
       - stereum_ufw_status.stdout.find("9000/tcp") != -1
       - stereum_ufw_status.stdout.find("9000/udp") != -1
+  # Lighthouse graffiti file
+  - stat: path=/opt/app/services/957fd49a-e63d-11ec-8d13-8f5d1bf7c1ca/graffitis/graffitis.yaml
+    register: graffitis
+  - debug:
+      msg: "{{ graffitis }}"
+  - name: Check for graffiti file
+    assert:
+      that: graffitis.stat.exists
   # Lighthouse api-token
   - stat: path=/opt/app/services/957fd49a-e63d-11ec-8d13-8f5d1bf7c1ca/validator/validators/api-token.txt
     register: api_token

--- a/controls/roles/validator-delete-api/molecule/prysm/prepare.yml
+++ b/controls/roles/validator-delete-api/molecule/prysm/prepare.yml
@@ -60,6 +60,7 @@
             save: true
             state: started
             configuration:
+              service: PrysmBeaconService
               id: "{{ beacon_service }}"
               image: prysmaticlabs/prysm-beacon-chain:HEAD-c8a7f6-debug
               ports:
@@ -167,11 +168,13 @@
                 --grpc-gateway-port=7500
                 --grpc-gateway-host=0.0.0.0
                 --grpc-gateway-corsdomain="*"
+                --graffiti-file=/opt/app/graffitis/graffitis.yaml
               user: "2000"
               volumes:
                 - "/opt/app/services/{{ validator_service }}/data/db:/opt/app/data/db"
                 - "/opt/app/services/{{ validator_service }}/data/wallets:/opt/app/data/wallets"
                 - "/opt/app/services/{{ validator_service }}/data/passwords:/opt/app/data/passwords"
+                - "/opt/app/services/{{ validator_service }}/graffitis:/opt/app/graffitis"
 
     - include_role:
         name: "validator-import-api"

--- a/controls/roles/validator-delete-api/molecule/prysm/verify.yml
+++ b/controls/roles/validator-delete-api/molecule/prysm/verify.yml
@@ -16,6 +16,14 @@
       that:
       - stereum_ufw_status.stdout.find("12000/udp") != -1
       - stereum_ufw_status.stdout.find("13000/tcp") != -1
+  # Prysm graffiti file
+  - stat: path=/opt/app/services/076e91e2-e8bc-11ec-84c1-37b5fd5ea8e1/graffitis/graffitis.yaml
+    register: graffitis
+  - debug:
+      msg: "{{ graffitis }}"
+  - name: Check for graffiti file
+    assert:
+      that: graffitis.stat.exists
   # Wallet & auth-token
   - stat: path=/opt/app/services/076e91e2-e8bc-11ec-84c1-37b5fd5ea8e1/data/wallets/direct/accounts/all-accounts.keystore.json
     register: validator_all_accounts

--- a/controls/roles/validator-delete-api/molecule/teku/prepare.yml
+++ b/controls/roles/validator-delete-api/molecule/teku/prepare.yml
@@ -107,7 +107,7 @@
                 - --p2p-enabled=true
                 - --p2p-port=9001
                 - --validators-keystore-locking-enabled=false
-                - --validators-graffiti="stereum.net"
+                - --validators-graffiti-file=/opt/app/graffitis/graffitis.yaml
                 - --ee-endpoint=http://10.10.0.3:8545
                 - --metrics-enabled=true
                 - --metrics-categories=BEACON,LIBP2P,NETWORK,PROCESS
@@ -131,6 +131,7 @@
               user: "2000"
               volumes:
                 - "/opt/app/services/{{ beacon_service }}/data:/opt/app/data"
+                - "/opt/app/services/{{ beacon_service }}/graffitis:/opt/app/graffitis"
 
     - name: Waiting for the services to start properly
       pause:

--- a/controls/roles/validator-delete-api/molecule/teku/verify.yml
+++ b/controls/roles/validator-delete-api/molecule/teku/verify.yml
@@ -16,6 +16,14 @@
       that:
       - stereum_ufw_status.stdout.find("9001/tcp") != -1
       - stereum_ufw_status.stdout.find("9001/udp") != -1
+  # Teku graffiti file
+  - stat: path=/opt/app/services/b5312c38-e8dd-11ec-9ddc-f331ef501d8f/graffitis/graffitis.yaml
+    register: graffitis
+  - debug:
+      msg: "{{ graffitis }}"
+  - name: Check for graffiti file
+    assert:
+      that: graffitis.stat.exists
   # teku API keystore, password & api bearer
   - stat: path=/opt/app/services/b5312c38-e8dd-11ec-9ddc-f331ef501d8f/data/teku_api_keystore
     register: teku_api_keystore

--- a/controls/roles/validator-fee-recipient-api/molecule/teku/prepare.yml
+++ b/controls/roles/validator-fee-recipient-api/molecule/teku/prepare.yml
@@ -107,7 +107,7 @@
                 - --p2p-enabled=true
                 - --p2p-port=9001
                 - --validators-keystore-locking-enabled=false
-                - --validators-graffiti="stereum.net"
+                - --validators-graffiti-file=/opt/app/graffitis/graffitis.yaml
                 - --ee-endpoint=http://10.10.0.3:8545
                 - --metrics-enabled=true
                 - --metrics-categories=BEACON,LIBP2P,NETWORK,PROCESS
@@ -131,6 +131,7 @@
               user: "2000"
               volumes:
                 - "/opt/app/services/{{ beacon_service }}/data:/opt/app/data"
+                - "/opt/app/services/{{ beacon_service }}/graffitis:/opt/app/graffitis"
 
     - name: Waiting for the services to start properly
       pause:

--- a/controls/roles/validator-fee-recipient-api/molecule/teku/verify.yml
+++ b/controls/roles/validator-fee-recipient-api/molecule/teku/verify.yml
@@ -16,6 +16,14 @@
       that:
       - stereum_ufw_status.stdout.find("9001/tcp") != -1
       - stereum_ufw_status.stdout.find("9001/udp") != -1
+  # Teku graffiti file
+  - stat: path=/opt/app/services/df8a069a-fca0-11ec-87b6-c3949203ceed/graffitis/graffitis.yaml
+    register: graffitis
+  - debug:
+      msg: "{{ graffitis }}"
+  - name: Check for graffiti file
+    assert:
+      that: graffitis.stat.exists
   # teku API keystore, password & api bearer
   - stat: path=/opt/app/services/df8a069a-fca0-11ec-87b6-c3949203ceed/data/teku_api_keystore
     register: teku_api_keystore

--- a/controls/roles/validator-import-api/molecule/lighthouse/prepare.yml
+++ b/controls/roles/validator-import-api/molecule/lighthouse/prepare.yml
@@ -101,7 +101,7 @@
                 - --beacon-nodes=http://stereum-{{ beacon_service }}:5052
                 - --datadir=/opt/app/validator
                 - --init-slashing-protection
-                - --graffiti="stereum.net"
+                - --graffiti-file=/opt/app/graffitis/graffitis.yaml
                 - --metrics
                 - --metrics-address=0.0.0.0
                 - --http
@@ -111,3 +111,4 @@
               user: "2000"
               volumes:
                 - "/opt/app/services/{{ validator_service }}/validator:/opt/app/validator"
+                - "/opt/app/services/{{ validator_service }}/graffitis:/opt/app/graffitis"

--- a/controls/roles/validator-import-api/molecule/lighthouse/verify.yml
+++ b/controls/roles/validator-import-api/molecule/lighthouse/verify.yml
@@ -16,6 +16,14 @@
       that:
       - stereum_ufw_status.stdout.find("9000/tcp") != -1
       - stereum_ufw_status.stdout.find("9000/udp") != -1
+  # Lighthouse graffiti file
+  - stat: path=/opt/app/services/0ca56612-998f-11ec-a28d-f71957ab65a0/graffitis/graffitis.yaml
+    register: graffitis
+  - debug:
+      msg: "{{ graffitis }}"
+  - name: Check for graffiti file
+    assert:
+      that: graffitis.stat.exists
   # Lighthouse api-token
   - stat: path=/opt/app/services/0ca56612-998f-11ec-a28d-f71957ab65a0/validator/validators/api-token.txt
     register: api_token

--- a/controls/roles/validator-import-api/molecule/prysm/prepare.yml
+++ b/controls/roles/validator-import-api/molecule/prysm/prepare.yml
@@ -158,8 +158,10 @@
                 --grpc-gateway-port=7500
                 --grpc-gateway-host=0.0.0.0
                 --grpc-gateway-corsdomain="*"
+                --graffiti-file=/opt/app/graffitis/graffitis.yaml
               user: "2000"
               volumes:
                 - "/opt/app/services/{{ validator_service }}/data/db:/opt/app/data/db"
                 - "/opt/app/services/{{ validator_service }}/data/wallets:/opt/app/data/wallets"
                 - "/opt/app/services/{{ validator_service }}/data/passwords:/opt/app/data/passwords"
+                - "/opt/app/services/{{ validator_service }}/graffitis:/opt/app/graffitis"

--- a/controls/roles/validator-import-api/molecule/prysm/verify.yml
+++ b/controls/roles/validator-import-api/molecule/prysm/verify.yml
@@ -22,6 +22,14 @@
       that:
       - stereum_ufw_status.stdout.find("12000/udp") != -1
       - stereum_ufw_status.stdout.find("13000/tcp") != -1
+  # Prysm graffiti file
+  - stat: path=/opt/app/services/0d4a2d58-b417-11ec-a0f3-0b91f10c3a8c/graffitis/graffitis.yaml
+    register: graffitis
+  - debug:
+      msg: "{{ graffitis }}"
+  - name: Check for graffiti file
+    assert:
+      that: graffitis.stat.exists
   # Wallet & auth-token
   - stat: path=/opt/app/services/0d4a2d58-b417-11ec-a0f3-0b91f10c3a8c/data/wallets/direct/accounts/all-accounts.keystore.json
     register: validator_all_accounts

--- a/controls/roles/validator-import-api/molecule/teku/prepare.yml
+++ b/controls/roles/validator-import-api/molecule/teku/prepare.yml
@@ -152,7 +152,7 @@
                 - --p2p-enabled=true
                 - --p2p-port=9001
                 - --validators-keystore-locking-enabled=false
-                - --validators-graffiti="stereum.net"
+                - --validators-graffiti-file=/opt/app/graffitis/graffitis.yaml
                 - --ee-endpoint=http://stereum-{{ geth_service }}:8551
                 - --metrics-enabled=true
                 - --metrics-categories=BEACON,LIBP2P,NETWORK,PROCESS
@@ -177,3 +177,4 @@
               volumes:
                 - "/opt/app/services/{{ beacon_service }}/data:/opt/app/data"
                 - "/opt/app/services/{{ geth_service }}/engine.jwt:/engine.jwt"
+                - "/opt/app/services/{{ beacon_service }}/graffitis:/opt/app/graffitis"

--- a/controls/roles/validator-import-api/molecule/teku/verify.yml
+++ b/controls/roles/validator-import-api/molecule/teku/verify.yml
@@ -16,6 +16,14 @@
       that:
       - stereum_ufw_status.stdout.find("9001/tcp") != -1
       - stereum_ufw_status.stdout.find("9001/udp") != -1
+  # Teku graffiti file
+  - stat: path=/opt/app/services/c3d37b1a-b51b-11ec-849b-6375f2b3a630/graffitis/graffitis.yaml
+    register: graffitis
+  - debug:
+      msg: "{{ graffitis }}"
+  - name: Check for graffiti file
+    assert:
+      that: graffitis.stat.exists
   # teku API keystore, password & api bearer
   - stat: path=/opt/app/services/c3d37b1a-b51b-11ec-849b-6375f2b3a630/data/teku_api_keystore
     register: teku_api_keystore

--- a/controls/roles/validator-list-api/molecule/lighthouse/prepare.yml
+++ b/controls/roles/validator-list-api/molecule/lighthouse/prepare.yml
@@ -54,6 +54,7 @@
             save: true
             state: started
             configuration:
+              service: LighthouseBeaconService
               id: "{{ beacon_service }}"
               image: "sigp/lighthouse:{{ stereum_static.defaults.versions.lighthouse }}"
               env: {}
@@ -109,7 +110,7 @@
                 - --beacon-nodes=http://stereum-{{ beacon_service }}:5052
                 - --datadir=/opt/app/validator
                 - --init-slashing-protection
-                - --graffiti="stereum.net"
+                - --graffiti-file=/opt/app/graffitis/graffitis.yaml
                 - --metrics
                 - --metrics-address=0.0.0.0
                 - --http
@@ -119,6 +120,7 @@
               user: "2000"
               volumes:
                 - "/opt/app/services/{{ validator_service }}/validator:/opt/app/validator"
+                - "/opt/app/services/{{ validator_service }}/graffitis:/opt/app/graffitis"
 
     - include_role:
         name: "validator-import-api"

--- a/controls/roles/validator-list-api/molecule/lighthouse/verify.yml
+++ b/controls/roles/validator-list-api/molecule/lighthouse/verify.yml
@@ -16,6 +16,14 @@
       that:
       - stereum_ufw_status.stdout.find("9000/tcp") != -1
       - stereum_ufw_status.stdout.find("9000/udp") != -1
+  # Lighthouse graffiti file
+  - stat: path=/opt/app/services/957fd49a-e63d-11ec-8d13-8f5d1bf7c1ca/graffitis/graffitis.yaml
+    register: graffitis
+  - debug:
+      msg: "{{ graffitis }}"
+  - name: Check for graffiti file
+    assert:
+      that: graffitis.stat.exists
   # Lighthouse api-token
   - stat: path=/opt/app/services/957fd49a-e63d-11ec-8d13-8f5d1bf7c1ca/validator/validators/api-token.txt
     register: api_token

--- a/controls/roles/validator-list-api/molecule/prysm/prepare.yml
+++ b/controls/roles/validator-list-api/molecule/prysm/prepare.yml
@@ -54,6 +54,7 @@
             save: true
             state: started
             configuration:
+              service: PrysmBeaconService
               id: "{{ beacon_service }}"
               image: prysmaticlabs/prysm-beacon-chain:HEAD-c8a7f6-debug
               ports:
@@ -161,11 +162,13 @@
                 --grpc-gateway-port=7500
                 --grpc-gateway-host=0.0.0.0
                 --grpc-gateway-corsdomain="*"
+                --graffiti-file=/opt/app/graffitis/graffitis.yaml
               user: "2000"
               volumes:
                 - "/opt/app/services/{{ validator_service }}/data/db:/opt/app/data/db"
                 - "/opt/app/services/{{ validator_service }}/data/wallets:/opt/app/data/wallets"
                 - "/opt/app/services/{{ validator_service }}/data/passwords:/opt/app/data/passwords"
+                - "/opt/app/services/{{ validator_service }}/graffitis:/opt/app/graffitis"
 
     - include_role:
         name: "validator-import-api"

--- a/controls/roles/validator-list-api/molecule/prysm/verify.yml
+++ b/controls/roles/validator-list-api/molecule/prysm/verify.yml
@@ -22,6 +22,14 @@
       that:
       - stereum_ufw_status.stdout.find("12000/udp") != -1
       - stereum_ufw_status.stdout.find("13000/tcp") != -1
+  # Prysm graffiti file
+  - stat: path=/opt/app/services/076e91e2-e8bc-11ec-84c1-37b5fd5ea8e1/graffitis/graffitis.yaml
+    register: graffitis
+  - debug:
+      msg: "{{ graffitis }}"
+  - name: Check for graffiti file
+    assert:
+      that: graffitis.stat.exists
   # Wallet & auth-token
   - stat: path=/opt/app/services/076e91e2-e8bc-11ec-84c1-37b5fd5ea8e1/data/wallets/direct/accounts/all-accounts.keystore.json
     register: validator_all_accounts

--- a/controls/roles/validator-list-api/molecule/teku/prepare.yml
+++ b/controls/roles/validator-list-api/molecule/teku/prepare.yml
@@ -107,7 +107,7 @@
                 - --p2p-enabled=true
                 - --p2p-port=9001
                 - --validators-keystore-locking-enabled=false
-                - --validators-graffiti="stereum.net"
+                - --validators-graffiti-file=/opt/app/graffitis/graffitis.yaml
                 - --ee-endpoint=http://10.10.0.3:8545
                 - --metrics-enabled=true
                 - --metrics-categories=BEACON,LIBP2P,NETWORK,PROCESS
@@ -131,6 +131,7 @@
               user: "2000"
               volumes:
                 - "/opt/app/services/{{ beacon_service }}/data:/opt/app/data"
+                - "/opt/app/services/{{ beacon_service }}/graffitis:/opt/app/graffitis"
 
     - name: Waiting for the services to start properly
       pause:

--- a/controls/roles/validator-list-api/molecule/teku/verify.yml
+++ b/controls/roles/validator-list-api/molecule/teku/verify.yml
@@ -16,6 +16,14 @@
       that:
       - stereum_ufw_status.stdout.find("9001/tcp") != -1
       - stereum_ufw_status.stdout.find("9001/udp") != -1
+  # Teku graffiti file
+  - stat: path=/opt/app/services/b5312c38-e8dd-11ec-9ddc-f331ef501d8f/graffitis/graffitis.yaml
+    register: graffitis
+  - debug:
+      msg: "{{ graffitis }}"
+  - name: Check for graffiti file
+    assert:
+      that: graffitis.stat.exists
   # teku API keystore, password & api bearer
   - stat: path=/opt/app/services/b5312c38-e8dd-11ec-9ddc-f331ef501d8f/data/teku_api_keystore
     register: teku_api_keystore

--- a/launcher/src/backend/OneClickInstall.js
+++ b/launcher/src/backend/OneClickInstall.js
@@ -161,7 +161,7 @@ export class OneClickInstall {
       ports = [
         new ServicePort('127.0.0.1', 5062, 5062, servicePortProtocol.tcp)
       ]
-      this.validatorService = LighthouseValidatorService.buildByUserInput(this.networkHandler(false), ports, this.installDir + '/lighthouse', [this.beaconService], 'stereum.net')
+      this.validatorService = LighthouseValidatorService.buildByUserInput(this.networkHandler(false), ports, this.installDir + '/lighthouse', [this.beaconService])
     }
 
     if (constellation.includes('PrysmBeaconService')) {
@@ -179,7 +179,7 @@ export class OneClickInstall {
       ports = [
         new ServicePort('127.0.0.1', 7500, 7500, servicePortProtocol.tcp)
       ]
-      this.validatorService = PrysmValidatorService.buildByUserInput(this.networkHandler(false), ports, this.installDir + '/prysm', [this.beaconService], 'stereum.net')
+      this.validatorService = PrysmValidatorService.buildByUserInput(this.networkHandler(false), ports, this.installDir + '/prysm', [this.beaconService])
     }
 
     if (constellation.includes('NimbusBeaconService')) {
@@ -190,7 +190,7 @@ export class OneClickInstall {
         new ServicePort('127.0.0.1', 9190, 9190, servicePortProtocol.tcp),
         new ServicePort('127.0.0.1', 5052, 5052, servicePortProtocol.tcp)
       ]
-      this.beaconService = NimbusBeaconService.buildByUserInput(this.networkHandler(false), ports, this.installDir + '/nimbus', [this.executionClient], 'stereum.net', checkpointURL)
+      this.beaconService = NimbusBeaconService.buildByUserInput(this.networkHandler(false), ports, this.installDir + '/nimbus', [this.executionClient], checkpointURL)
 
       //generate validator api-token
       const valDir = (this.beaconService.volumes.find(vol => vol.servicePath === '/opt/app/validators')).destinationPath
@@ -207,7 +207,7 @@ export class OneClickInstall {
         new ServicePort('127.0.0.1', 5051, 5051, servicePortProtocol.tcp),
         new ServicePort('127.0.0.1', 5052, 5052, servicePortProtocol.tcp),
       ]
-      this.beaconService = TekuBeaconService.buildByUserInput(this.networkHandler(false), ports, this.installDir + '/teku', [this.executionClient], 'stereum.net', checkpointURL)
+      this.beaconService = TekuBeaconService.buildByUserInput(this.networkHandler(false), ports, this.installDir + '/teku', [this.executionClient], checkpointURL)
 
       //keystore
       const dataDir = (this.beaconService.volumes.find(vol => vol.servicePath === '/opt/app/data')).destinationPath

--- a/launcher/src/backend/ValidatorAccountManager.js
+++ b/launcher/src/backend/ValidatorAccountManager.js
@@ -230,39 +230,45 @@ export class ValidatorAccountManager {
 
     async setGraffitis(graffiti){
         let services = await this.serviceManager.readServiceConfigurations()
-        let client = undefined
-        let possibilities = ['Validator', 'Beacon']
-        let i = 0
-        while (client === undefined && i <= 1) {
-            client = (services.find(service => service.service.includes(possibilities[i])))
-            i++
-        }
-        let service = (client.service.replace(/(Beacon|Validator|Service)/gm, '')).toLowerCase()
+        let validators = await services.filter(service => {
+            if(
+                service.service.includes("Teku") ||
+                service.service.includes("Nimbus") ||
+                service.service.includes("Validator")
+            ){
+                return true
+            }
+            return false
+        })
 
-        const graffitiDir = (client.volumes.find(vol => vol.servicePath === '/opt/app/graffitis')).destinationPath + '/graffitis.yaml'
-        let config = ""
-        switch (service) {
-            case "lighthouse":
-                config = `default: ${graffiti}`
-                await this.nodeConnection.sshService.exec('echo ' + StringUtils.escapeStringForShell(config) + ' > ' + graffitiDir)
-                break;
-        
-            case "prysm":
-                config = `default: "${graffiti}"`
-                await this.nodeConnection.sshService.exec('echo ' + StringUtils.escapeStringForShell(config) + ' > ' + graffitiDir)
-                break;
-        
-            case "nimbus":
-                //Nimbus only supports Graffiti changes while running via their rest api
-                break;
-        
-            case "teku":
-                config = graffiti
-                await this.nodeConnection.sshService.exec('echo ' + StringUtils.escapeStringForShell(config) + ' > ' + graffitiDir)
-                break;
-        
-            default:
-                break;
+        for(let client of validators){
+            let service = (client.service.replace(/(Beacon|Validator|Service)/gm, '')).toLowerCase()
+            
+            const graffitiDir = (client.volumes.find(vol => vol.servicePath === '/opt/app/graffitis')).destinationPath + '/graffitis.yaml'
+            let config = ""
+            switch (service) {
+                case "lighthouse":
+                    config = `default: ${graffiti}`
+                    await this.nodeConnection.sshService.exec('echo ' + StringUtils.escapeStringForShell(config) + ' > ' + graffitiDir)
+                    break;
+            
+                case "prysm":
+                    config = `default: "${graffiti}"`
+                    await this.nodeConnection.sshService.exec('echo ' + StringUtils.escapeStringForShell(config) + ' > ' + graffitiDir)
+                    break;
+            
+                case "nimbus":
+                    //Nimbus only supports Graffiti changes while running via their rest api
+                    break;
+            
+                case "teku":
+                    config = graffiti
+                    await this.nodeConnection.sshService.exec('echo ' + StringUtils.escapeStringForShell(config) + ' > ' + graffitiDir)
+                    break;
+            
+                default:
+                    break;
+            }
         }
     }
 

--- a/launcher/src/backend/ValidatorAccountManager.js
+++ b/launcher/src/backend/ValidatorAccountManager.js
@@ -228,4 +228,42 @@ export class ValidatorAccountManager {
         return URL
     }
 
+    async setGraffitis(graffiti){
+        let services = await this.serviceManager.readServiceConfigurations()
+        let client = undefined
+        let possibilities = ['Validator', 'Beacon']
+        let i = 0
+        while (client === undefined && i <= 1) {
+            client = (services.find(service => service.service.includes(possibilities[i])))
+            i++
+        }
+        let service = (client.service.replace(/(Beacon|Validator|Service)/gm, '')).toLowerCase()
+
+        const graffitiDir = (client.volumes.find(vol => vol.servicePath === '/opt/app/graffitis')).destinationPath + '/graffitis.yaml'
+        let config = ""
+        switch (service) {
+            case "lighthouse":
+                config = `default: ${graffiti}`
+                await this.nodeConnection.sshService.exec('echo ' + StringUtils.escapeStringForShell(config) + ' > ' + graffitiDir)
+                break;
+        
+            case "prysm":
+                config = `default: "${graffiti}"`
+                await this.nodeConnection.sshService.exec('echo ' + StringUtils.escapeStringForShell(config) + ' > ' + graffitiDir)
+                break;
+        
+            case "nimbus":
+                //Nimbus only supports Graffiti changes while running via their rest api
+                break;
+        
+            case "teku":
+                config = graffiti
+                await this.nodeConnection.sshService.exec('echo ' + StringUtils.escapeStringForShell(config) + ' > ' + graffitiDir)
+                break;
+        
+            default:
+                break;
+        }
+    }
+
 }

--- a/launcher/src/backend/ethereum-services/LighthouseBeaconService.int.js
+++ b/launcher/src/backend/ethereum-services/LighthouseBeaconService.int.js
@@ -78,7 +78,7 @@ test('lighthouse validator import', async () => {
     ports = [
         new ServicePort('127.0.0.1', 5062, 5062, servicePortProtocol.tcp)
     ]
-    let lhVC = LighthouseValidatorService.buildByUserInput('prater', ports, nodeConnection.settings.stereum.settings.controls_install_path + '/lighthouse', [lhBC], 'stereum.net')
+    let lhVC = LighthouseValidatorService.buildByUserInput('prater', ports, nodeConnection.settings.stereum.settings.controls_install_path + '/lighthouse', [lhBC])
 
     await nodeConnection.writeServiceConfiguration(geth.buildConfiguration()),
     await serviceManager.manageServiceState(geth.id, 'started')

--- a/launcher/src/backend/ethereum-services/LighthouseValidatorService.js
+++ b/launcher/src/backend/ethereum-services/LighthouseValidatorService.js
@@ -4,7 +4,7 @@ import { ServiceVolume } from './ServiceVolume.js'
 
 
 export class LighthouseValidatorService extends NodeService {
-  static buildByUserInput (network, ports, dir, consensusClients, graffiti) {
+  static buildByUserInput (network, ports, dir, consensusClients) {
     const service = new LighthouseValidatorService()
     service.setId()
     const workingDir = service.buildWorkingDir(dir)
@@ -12,9 +12,11 @@ export class LighthouseValidatorService extends NodeService {
     const image = 'sigp/lighthouse'
 
     const dataDir = '/opt/app/validator'
+    const graffitiDir = '/opt/app/graffitis'
 
     const volumes = [
-      new ServiceVolume(workingDir + '/validator', dataDir)
+      new ServiceVolume(workingDir + '/validator', dataDir),
+      new ServiceVolume(workingDir + '/graffitis', graffitiDir)
     ]
 
     const eth2Nodes = (consensusClients.map(client => { return client.buildConsensusClientHttpEndpointUrl() })).join()
@@ -35,7 +37,7 @@ export class LighthouseValidatorService extends NodeService {
         '--suggested-fee-recipient=0x0000000000000000000000000000000000000000',
         `--datadir=${dataDir}`,
         '--init-slashing-protection',
-        `--graffiti=\"${graffiti}\"`,
+        `--graffiti-file=${graffitiDir}/graffitis.yaml`,
         '--metrics',
         '--metrics-address=0.0.0.0',
         '--http',

--- a/launcher/src/backend/ethereum-services/LighthouseValidatorService.test.js
+++ b/launcher/src/backend/ethereum-services/LighthouseValidatorService.test.js
@@ -21,14 +21,14 @@ test('LighthouseValidatorService buildConfiguration', () => {
     new ServicePort('1.2.3.4', 303, 404, servicePortProtocol.udp)
   ]
 
-  const lhService = LighthouseValidatorService.buildByUserInput(networks.prater, ports, '/opt/stereum/lh', [new LighthouseBeaconService.LighthouseBeaconService()], 'foobar').buildConfiguration()
+  const lhService = LighthouseValidatorService.buildByUserInput(networks.prater, ports, '/opt/stereum/lh', [new LighthouseBeaconService.LighthouseBeaconService()]).buildConfiguration()
 
 
 
   expect(lhService.command).toContain('--beacon-nodes=http-endpoint-string')
-  expect(lhService.command).toContain('--graffiti=\"foobar\"')
-  expect(lhService.volumes).toHaveLength(1)
+  expect(lhService.volumes).toHaveLength(2)
   expect(lhService.volumes).toContain('/opt/stereum/lh-' + lhService.id + '/validator:/opt/app/validator')
+  expect(lhService.volumes).toContain('/opt/stereum/lh-' + lhService.id + '/graffitis:/opt/app/graffitis')
   expect(lhService.ports).toHaveLength(1)
   expect(lhService.id).toHaveLength(36)
   expect(lhService.user).toMatch(/2000/)

--- a/launcher/src/backend/ethereum-services/NimbusBeaconService.int.js
+++ b/launcher/src/backend/ethereum-services/NimbusBeaconService.int.js
@@ -72,7 +72,7 @@ test('nimbus validator import', async () => {
         new ServicePort('127.0.0.1', 9190, 9190, servicePortProtocol.tcp),
         new ServicePort('127.0.0.1', 5052, 5052, servicePortProtocol.tcp)
     ]
-    let nimbusClient = NimbusBeaconService.buildByUserInput('prater', ports, nodeConnection.settings.stereum.settings.controls_install_path + '/nimbus', [geth], 'stereum.net')
+    let nimbusClient = NimbusBeaconService.buildByUserInput('prater', ports, nodeConnection.settings.stereum.settings.controls_install_path + '/nimbus', [geth])
     //change out web3 address for integration test
     // const index = nimbusClient.command.findIndex(element => element.includes('--web3-url='))
     // nimbusClient.command[index] = '--web3-url=ws://10.10.0.2:8545'

--- a/launcher/src/backend/ethereum-services/NimbusBeaconService.js
+++ b/launcher/src/backend/ethereum-services/NimbusBeaconService.js
@@ -3,7 +3,7 @@ import { ServicePortDefinition } from './SerivcePortDefinition.js'
 import { ServiceVolume } from './ServiceVolume.js'
 
 export class NimbusBeaconService extends NodeService {
-  static buildByUserInput (network, ports, dir, executionClients, graffiti, checkpointURL) {
+  static buildByUserInput (network, ports, dir, executionClients, checkpointURL) {
     const service = new NimbusBeaconService()
     service.setId()
     const workingDir = service.buildWorkingDir(dir)
@@ -45,7 +45,7 @@ export class NimbusBeaconService extends NodeService {
         '--rest',
         '--rest-address=0.0.0.0',
         '--rest-port=5052',
-        `--graffiti=\"${graffiti}\"`,
+        `--graffiti=\"stereum.net\"`,
         '--keymanager',
         '--keymanager-address=0.0.0.0',
         '--keymanager-token-file=/opt/app/validators/api-token.txt',

--- a/launcher/src/backend/ethereum-services/PrysmValidatorService.js
+++ b/launcher/src/backend/ethereum-services/PrysmValidatorService.js
@@ -3,7 +3,7 @@ import { ServicePortDefinition } from './SerivcePortDefinition.js'
 import { ServiceVolume } from './ServiceVolume.js'
 
 export class PrysmValidatorService extends NodeService {
-    static buildByUserInput(network, ports, dir, consensusClients, graffiti) {
+    static buildByUserInput(network, ports, dir, consensusClients) {
         const service = new PrysmValidatorService()
         service.setId()
         const workingDir = service.buildWorkingDir(dir)
@@ -13,11 +13,13 @@ export class PrysmValidatorService extends NodeService {
         const dataDir = '/opt/app/data/db'
         const walletDir = '/opt/app/data/wallets'
         const passwordDir = '/opt/app/data/passwords'
+        const graffitiDir = '/opt/app/graffitis'
 
         const volumes = [
             new ServiceVolume(workingDir + '/data/db', dataDir),
             new ServiceVolume(workingDir + '/data/wallets', walletDir),
-            new ServiceVolume(workingDir + '/data/passwords', passwordDir)
+            new ServiceVolume(workingDir + '/data/passwords', passwordDir),
+            new ServiceVolume(workingDir + '/graffitis', graffitiDir)
         ]
 
         const provider = (consensusClients.map(client => { return client.buildConsensusClientEndpoint() })).shift()
@@ -29,7 +31,7 @@ export class PrysmValidatorService extends NodeService {
             1, // configVersion 
             image,  //image
             'v2.1.4-rc.0', //imageVersion
-            '/app/cmd/validator/validator --accept-terms-of-use=true --beacon-rpc-provider="' + provider + '" --beacon-rpc-gateway-provider="' + providerGateway + '" --web --' + network + '=true --datadir=' + dataDir + ' --wallet-dir=' + walletDir + ' --wallet-password-file=' + passwordDir + '/wallet-password --monitoring-host=0.0.0.0 --grpc-gateway-port=7500 --grpc-gateway-host=0.0.0.0 --grpc-gateway-corsdomain="*"  --monitoring-host=0.0.0.0 --monitoring-port=8081 --suggested-fee-recipient=0x0000000000000000000000000000000000000000',  //command
+            '/app/cmd/validator/validator --accept-terms-of-use=true --beacon-rpc-provider="' + provider + '" --beacon-rpc-gateway-provider="' + providerGateway + '" --web --' + network + '=true --datadir=' + dataDir + ' --wallet-dir=' + walletDir + ' --wallet-password-file=' + passwordDir + '/wallet-password --monitoring-host=0.0.0.0 --grpc-gateway-port=7500 --grpc-gateway-host=0.0.0.0 --grpc-gateway-corsdomain="*"  --monitoring-host=0.0.0.0 --monitoring-port=8081 --suggested-fee-recipient=0x0000000000000000000000000000000000000000' + ' --graffiti-file='+ graffitiDir +'/graffitis.yaml',  //command
             null, // entrypoint
             null, // env
             ports, //ports

--- a/launcher/src/backend/ethereum-services/PrysmValidatorService.test.js
+++ b/launcher/src/backend/ethereum-services/PrysmValidatorService.test.js
@@ -27,10 +27,11 @@ test('buildConfiguration', () => {
   
     expect(prysm.command).toMatch(/--beacon-rpc-provider=\"buildConsensusClientEndpoint\"/)
     expect(prysm.command).toMatch(/--beacon-rpc-gateway-provider=\"buildConsensusClientGateway\"/)
-    expect(prysm.volumes).toHaveLength(3)
+    expect(prysm.volumes).toHaveLength(4)
     expect(prysm.volumes).toContain('/opt/stereum/prysm-' + prysm.id + '/data/db:/opt/app/data/db')
     expect(prysm.volumes).toContain('/opt/stereum/prysm-' + prysm.id + '/data/wallets:/opt/app/data/wallets')
     expect(prysm.volumes).toContain('/opt/stereum/prysm-' + prysm.id + '/data/passwords:/opt/app/data/passwords')
+    expect(prysm.volumes).toContain('/opt/stereum/prysm-' + prysm.id + '/graffitis:/opt/app/graffitis')
     expect(prysm.ports).toHaveLength(1)
     expect(prysm.id).toHaveLength(36)
     expect(prysm.user).toMatch(/2000/)

--- a/launcher/src/backend/ethereum-services/TekuBeaconService.int.js
+++ b/launcher/src/backend/ethereum-services/TekuBeaconService.int.js
@@ -72,7 +72,7 @@ test('teku validator import', async () => {
       new ServicePort('127.0.0.1', 5052, 5052, servicePortProtocol.tcp),
       new ServicePort('127.0.0.1', 8008, 8008, servicePortProtocol.tcp)
     ]
-    let tekuClient = TekuBeaconService.buildByUserInput('prater', ports, nodeConnection.settings.stereum.settings.controls_install_path + '/teku', [geth], 'stereum.net')
+    let tekuClient = TekuBeaconService.buildByUserInput('prater', ports, nodeConnection.settings.stereum.settings.controls_install_path + '/teku', [geth])
     //change out eth1 endpoint address for integration test
     // const index = tekuClient.command.findIndex(element => element.includes('--ee-endpoint='))
     // tekuClient.command[index] = '--ee-endpoint==http://10.10.0.3:8545'

--- a/launcher/src/backend/ethereum-services/TekuBeaconService.js
+++ b/launcher/src/backend/ethereum-services/TekuBeaconService.js
@@ -3,7 +3,7 @@ import { ServicePortDefinition } from './SerivcePortDefinition.js'
 import { ServiceVolume } from './ServiceVolume.js'
 
 export class TekuBeaconService extends NodeService {
-    static buildByUserInput(network, ports, dir, executionClients, graffiti, checkpointURL) {
+    static buildByUserInput(network, ports, dir, executionClients, checkpointURL) {
         const service = new TekuBeaconService()
         service.setId()
         const workingDir = service.buildWorkingDir(dir)
@@ -15,9 +15,12 @@ export class TekuBeaconService extends NodeService {
 
         const JWTDir = '/engine.jwt'
         const dataDir = '/opt/app/data'
+        const graffitiDir = '/opt/app/graffitis'
+
         const volumes = [
             new ServiceVolume(workingDir + '/data', dataDir),
-            new ServiceVolume(elJWTDir, JWTDir)
+            new ServiceVolume(elJWTDir, JWTDir),
+            new ServiceVolume(workingDir + '/graffitis', graffitiDir)
         ]
     
         service.init(
@@ -32,7 +35,7 @@ export class TekuBeaconService extends NodeService {
                 '--p2p-enabled=true',
                 '--p2p-port=9001',
                 '--validators-keystore-locking-enabled=false',
-                `--validators-graffiti="${graffiti}"`,
+                `--validators-graffiti-file=${graffitiDir}/graffitis.yaml`,
                 //`--eth1-endpoints=${executionLayer}`,
                 `--ee-endpoint=${executionLayer}`,
                 `--ee-jwt-secret-file=${JWTDir}`,

--- a/launcher/src/backend/ethereum-services/TekuBeaconService.test.js
+++ b/launcher/src/backend/ethereum-services/TekuBeaconService.test.js
@@ -31,13 +31,12 @@ test('buildConfiguration', () => {
       }
     })
   
-    const tekuService = TekuBeaconService.buildByUserInput(networks.prater, ports, '/opt/stereum/teku', [new GethService.GethService()], 'stereum.net').buildConfiguration()
+    const tekuService = TekuBeaconService.buildByUserInput(networks.prater, ports, '/opt/stereum/teku', [new GethService.GethService()]).buildConfiguration()
   
     expect(tekuService.command).toContain('--ee-endpoint=http-endpoint-string')
     expect(tekuService.command).toContain('--network=prater')
-    expect(tekuService.command).toContain('--validators-graffiti="stereum.net"')
-    expect(tekuService.volumes).toHaveLength(2)
-    expect(tekuService.volumes).toContain('/opt/stereum/teku-' + tekuService.id + '/data:/opt/app/data')
+    expect(tekuService.volumes).toHaveLength(3)
+    expect(tekuService.volumes).toContain('/opt/stereum/teku-' + tekuService.id + '/graffitis:/opt/app/graffitis')
     expect(tekuService.ports).toHaveLength(5)
     expect(tekuService.id).toHaveLength(36)
     expect(tekuService.user).toMatch(/2000/)

--- a/launcher/src/background.js
+++ b/launcher/src/background.js
@@ -287,6 +287,10 @@ promiseIpc.on("getOperatorPageURL", async (args) => {
   return await validatorAccountManager.getOperatorPageURL(args);
 });
 
+promiseIpc.on("setGraffitis", async (args) => {
+  return await validatorAccountManager.setGraffitis(args)
+})
+
 // Scheme must be registered before the app is ready
 protocol.registerSchemesAsPrivileged([
   { scheme: "app", privileges: { secure: true, standard: true } },

--- a/launcher/src/components/UI/the-staking/DisplayValidators.vue
+++ b/launcher/src/components/UI/the-staking/DisplayValidators.vue
@@ -578,7 +578,8 @@ export default {
     hideBDialog() {
       this.bDialogVisible = false;
     },
-    confirmEnteredGrafiti() {
+    async confirmEnteredGrafiti(graffiti) {
+      await ControlService.setGraffitis(graffiti)
       this.grafitiForMultiValidatorsActive = false;
       this.insertKeyBoxActive = true;
     },

--- a/launcher/src/components/UI/the-staking/GrafitiMultipleValidators.vue
+++ b/launcher/src/components/UI/the-staking/GrafitiMultipleValidators.vue
@@ -12,10 +12,11 @@
         <input
           type="text"
           placeholder="Enter up 32 characters to add to the chain when you create a block!"
+          v-model="graffiti"
         />
       </div>
       <div class="confirmBox">
-        <button class="confirmBtn" @click="$emit('confirmBtn')">
+        <button class="confirmBtn" @click="$emit('confirmBtn', this.graffiti)">
           Confrim
         </button>
       </div>
@@ -24,7 +25,11 @@
 </template>
 <script>
 export default {
-
+  data(){
+    return{
+      graffiti: ""
+    };
+  },
 };
 </script>
 <style scoped>

--- a/launcher/src/store/ControlService.js
+++ b/launcher/src/store/ControlService.js
@@ -213,6 +213,10 @@ class ControlService extends EventEmitter {
   async getOperatorPageURL(args) {
     return await this.promiseIpc.send("getOperatorPageURL", args); // insert existing operator keys
   }
+
+  async setGraffitis(args) {
+    return await this.promiseIpc.send("setGraffitis", args);
+  }
 }
 if (!instance) {
   instance = new ControlService(window.electron);


### PR DESCRIPTION
Changing graffitis for all keys for Lighthouse, Prysm and Teku Nodes is now possible. 
On Nimbus nodes the only way to change the graffiti while the service is running, is via their rest api.
Doing this via ansible and curl would slow things down a lot, so i left it open for now