### PR TITLE
ADD: updating to HEAD

### DIFF
--- a/launcher/src/backend/NodeConnection.js
+++ b/launcher/src/backend/NodeConnection.js
@@ -819,6 +819,8 @@ export class NodeConnection {
   async checkUpdates() {
     try {
       let response = await axios.get('https://stereum.net/downloads/updates.json')
+      if(global.branch === "main")
+        response.data.stereum.push({name: "HEAD", commit: 'main'})
       log.debug(response.data)
       return response.data
     } catch (err) {


### PR DESCRIPTION
By setting the env var `IS_DEV=true`
Stereum-Controls-Updates are always updating to HEAD of main