### PR TITLE
REFACTOR: disable rpc and datapi widgets

### DIFF
--- a/launcher/src/components/UI/the-control/DataApi.vue
+++ b/launcher/src/components/UI/the-control/DataApi.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="dataApi-parent">
+    <comming-soon></comming-soon>
     <control-dialog :open="openDialog"
       ><div class="dialogBox">
         <div class="dialogIcon"><img :src="copyIcon" /></div>

--- a/launcher/src/components/UI/the-control/DataApi.vue
+++ b/launcher/src/components/UI/the-control/DataApi.vue
@@ -145,7 +145,7 @@ export default {
   height: 100%;
 }
 .spinner img {
-  width: 100%;
+  width: 80%;
 }
 .dataApi-parent {
   display: flex;

--- a/launcher/src/components/UI/the-control/RpcEndpoint.vue
+++ b/launcher/src/components/UI/the-control/RpcEndpoint.vue
@@ -147,7 +147,7 @@ export default {
   height: 100%;
 }
 .spinner img {
-  width: 100%;
+  width: 80%;
 }
 .rpc-parent {
   display: flex;

--- a/launcher/src/components/UI/the-control/RpcEndpoint.vue
+++ b/launcher/src/components/UI/the-control/RpcEndpoint.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="rpc-parent">
+    <comming-soon></comming-soon>
     <control-dialog :open="openDialog"
       ><div class="dialogBox">
         <div class="dialogIcon"><img :src="copyIcon" /></div>


### PR DESCRIPTION
Until port mapping for existing nodes is implemented via ansible