### PR TITLE
UPDATE: update docker images in molecule test

### DIFF
--- a/controls/defaults/stereum_defaults.yaml
+++ b/controls/defaults/stereum_defaults.yaml
@@ -10,29 +10,29 @@ stereum_static:
         install: false
     versions:
       # consensus clients
-      lighthouse: v3.1.0
-      nimbus: multiarch-v22.9.0
-      teku: "22.9.1"
+      lighthouse: v3.1.2
+      nimbus: multiarch-v22.10.1
+      teku: "22.10.1"
       prysm: v3.1.1
-      lodestar: v1.0.0
+      lodestar: v1.1.0
 
       # execution clients
       geth: v1.10.25
       besu: "22.7.2"
-      nethermind: "1.14.2"
-      erigon: v2022.09.03
+      nethermind: "1.14.3"
+      erigon: v2.28.1
 
       # mevboost
-      mevboost: v1.3.1
+      mevboost: v1.3.2
 
       # ssv
-      ssv_network: v0.3.0
+      ssv_network: v0.3.3
 
       # tools
       curl: "7.85.0"
-      grafana: "9.1.6"
-      node_exporter: v1.3.1
-      prometheus: v2.37.1
+      grafana: "9.2.1"
+      node_exporter: v1.4.0
+      prometheus: v2.39.1
       notifications: v1.1.0
 
     # mevboost - relay


### PR DESCRIPTION
CL

lighthouse: https://github.com/sigp/lighthouse/releases/tag/v3.1.2
nimbus: https://github.com/status-im/nimbus-eth2/releases/tag/v22.10.1
teku: https://github.com/ConsenSys/teku/releases/tag/22.10.1
lodestar: https://github.com/ChainSafe/lodestar/releases/tag/v1.1.0

EL

besu: https://github.com/hyperledger/besu/releases/tag/22.7.6
nethermind: https://github.com/NethermindEth/nethermind/releases/tag/1.14.3
erigon: https://github.com/ledgerwatch/erigon/releases/tag/v2.28.1

Others:

mevboost: https://github.com/flashbots/mev-boost/releases/tag/v1.3.2
blox-SSV: https://github.com/bloxapp/ssv/releases/tag/v0.3.3

Monitoring:

grafana: https://github.com/grafana/grafana/releases/tag/v9.2.1
node_exporter: https://github.com/prometheus/node_exporter/releases/tag/v1.4.0
prometheus: https://github.com/prometheus/prometheus/releases/tag/v2.39.1
