### PR TITLE
FIX: geth losing state on start/stop

### DIFF
--- a/controls/roles/manage-service/tasks/main.yml
+++ b/controls/roles/manage-service/tasks/main.yml
@@ -26,6 +26,7 @@
   - name: Stop service
     docker_container:
       name: "{{ stereum_service_container_name }}"
+      stop_timeout: 180
       state: absent
     become: yes
     when: stereum.manage_service.state == "stopped" or stereum.manage_service.state == "restarted"


### PR DESCRIPTION
Sometimes, especially on mainnet, Geth loses its state and needs to resync from an old data point. This causes unnecessary downtime.

This fix also helps other services to gracefully shutdown with a higher timeout on stopping services.