### PR TITLE
UPDATE: docker images in molecule test

### DIFF
--- a/controls/defaults/stereum_defaults.yaml
+++ b/controls/defaults/stereum_defaults.yaml
@@ -19,7 +19,7 @@ stereum_static:
       # execution clients
       geth: v1.10.26
       besu: "22.10.0"
-      nethermind: "1.14.3"
+      nethermind: "v1.14.6"
       erigon: v2.30.0
 
       # mevboost

--- a/controls/defaults/stereum_defaults.yaml
+++ b/controls/defaults/stereum_defaults.yaml
@@ -10,29 +10,29 @@ stereum_static:
         install: false
     versions:
       # consensus clients
-      lighthouse: v3.1.2
+      lighthouse:  v3.2.1
       nimbus: multiarch-v22.10.1
-      teku: "22.10.2"
-      prysm: v3.1.1
-      lodestar: v1.1.0
+      teku: "22.11.0"
+      prysm: v3.1.2
+      lodestar: v1.2.1
 
       # execution clients
-      geth: v1.10.25
-      besu: "22.7.2"
+      geth: v1.10.26
+      besu: "22.10.0"
       nethermind: "1.14.3"
-      erigon: v2.28.1
+      erigon: v2.30.0
 
       # mevboost
-      mevboost: v1.3.2
+      mevboost: v1.4.0
 
       # ssv
-      ssv_network: v0.3.3
+      ssv_network: v0.3.4
 
       # tools
       curl: "7.85.0"
-      grafana: "9.2.1"
+      grafana: "9.2.5"
       node_exporter: v1.4.0
-      prometheus: v2.39.1
+      prometheus:  v2.40.2
       notifications: v1.1.0
 
     # mevboost - relay


### PR DESCRIPTION
lh: https://github.com/sigp/lighthouse/releases/tag/v3.2.1
nimbus: https://github.com/status-im/nimbus-eth2/releases/tag/v22.10.1
teku: https://github.com/ConsenSys/teku/releases/tag/22.11.0
prysm: https://github.com/prysmaticlabs/prysm/releases/tag/v3.1.2
lodestar: https://github.com/ChainSafe/lodestar/releases/tag/v1.2.1

geth: https://github.com/ethereum/go-ethereum/releases/tag/v1.10.26
nethermind: https://github.com/NethermindEth/nethermind/releases

mevboost: https://github.com/flashbots/mev-boost/releases
ssv: https://github.com/bloxapp/ssv/releases

grafana: https://github.com/grafana/grafana/releases
prometheus: https://github.com/grafana/grafana/releases