### PR TITLE
ADD: teku cert rollout

### DIFF
--- a/.github/workflows/test-molecule.yml
+++ b/.github/workflows/test-molecule.yml
@@ -68,7 +68,8 @@ jobs:
         tests: [
           {role: "update-changes", test: "20-rc3"},
           {role: "update-changes", test: "20-rc6"},
-          {role: "update-changes", test: "20-rc7"}
+          {role: "update-changes", test: "20-rc7"},
+          {role: "update-changes", test: "20-rc9"}
         ]
       fail-fast: false
     concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}

--- a/controls/roles/manage-service/molecule/mevboost-besu-teku/converge.yml
+++ b/controls/roles/manage-service/molecule/mevboost-besu-teku/converge.yml
@@ -88,8 +88,8 @@
                           -keyalg RSA
                           -keysize 2048
                           -validity 109500
-                          -dname 'CN=localhost, OU=MyCompanyUnit, O=MyCompany, L=MyCity, ST=MyState, C=AU'
-                          -ext san=dns:localhost,ip:127.0.0.1"
+                          -dname 'CN=teku, OU=MyCompanyUnit, O=MyCompany, L=MyCity, ST=MyState, C=AU'
+                          -ext 'SAN=DNS:stereum-{{ teku_service }}'"
         args:
           chdir: /opt/app/services/{{ teku_service }}/data
         changed_when: false

--- a/controls/roles/manage-service/molecule/mevboost-geth-teku/converge.yml
+++ b/controls/roles/manage-service/molecule/mevboost-geth-teku/converge.yml
@@ -80,8 +80,8 @@
                           -keyalg RSA
                           -keysize 2048
                           -validity 109500
-                          -dname 'CN=localhost, OU=MyCompanyUnit, O=MyCompany, L=MyCity, ST=MyState, C=AU'
-                          -ext san=dns:localhost,ip:127.0.0.1"
+                          -dname 'CN=teku, OU=MyCompanyUnit, O=MyCompany, L=MyCity, ST=MyState, C=AU'
+                          -ext 'SAN=DNS:stereum-{{ teku_service }}'"
         args:
           chdir: /opt/app/services/{{ teku_service }}/data
         changed_when: false

--- a/controls/roles/manage-service/molecule/mevboost-nethermind-teku/converge.yml
+++ b/controls/roles/manage-service/molecule/mevboost-nethermind-teku/converge.yml
@@ -76,8 +76,8 @@
                           -keyalg RSA
                           -keysize 2048
                           -validity 109500
-                          -dname 'CN=localhost, OU=MyCompanyUnit, O=MyCompany, L=MyCity, ST=MyState, C=AU'
-                          -ext san=dns:localhost,ip:127.0.0.1"
+                          -dname 'CN=teku, OU=MyCompanyUnit, O=MyCompany, L=MyCity, ST=MyState, C=AU'
+                          -ext 'SAN=DNS:stereum-{{ teku_service }}'"
         args:
           chdir: /opt/app/services/{{ teku_service }}/data
         changed_when: false

--- a/controls/roles/update-changes/molecule/20-rc9/converge.yml
+++ b/controls/roles/update-changes/molecule/20-rc9/converge.yml
@@ -1,0 +1,10 @@
+---
+- name: Converge
+  hosts: all
+  vars_files:
+  - ../../../../defaults/stereum_defaults.yaml
+
+  tasks:
+    - name: "Include update-changes"
+      include_role:
+        name: "update-changes"

--- a/controls/roles/update-changes/molecule/20-rc9/molecule.yml
+++ b/controls/roles/update-changes/molecule/20-rc9/molecule.yml
@@ -1,0 +1,28 @@
+---
+#dependency:
+#  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: "update-changes--20-rc9--ubuntu-22.04"
+    image: ubuntu:jammy
+ # - name: "configure-updates--default--centos-8"
+ #   image: geerlingguy/docker-centos8-ansible
+provisioner:
+  name: ansible
+  env:
+    ANSIBLE_PIPELINING: "True"
+lint: |
+  set -e
+  yamllint .
+  ansible-lint .
+scenario:
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - lint
+    - verify
+    - destroy

--- a/controls/roles/update-changes/molecule/20-rc9/playbook.yml
+++ b/controls/roles/update-changes/molecule/20-rc9/playbook.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: "Include update-changes"
+      include_role:
+        name: "update-changes"

--- a/controls/roles/update-changes/molecule/20-rc9/prepare.yml
+++ b/controls/roles/update-changes/molecule/20-rc9/prepare.yml
@@ -1,0 +1,252 @@
+---
+- name: Prepare
+  hosts: all
+  tasks:
+    - name: Make sure Stereum's config path exists
+      file:
+        path: "/etc/stereum/services"
+        state: directory
+        owner: "root"
+        group: "root"
+        mode: 0644
+      become: yes
+    
+    - name: Create Teku service config
+      copy:
+        dest: "/etc/stereum/services/61cb4672-f069-4416-bf2a-db53a0776395.yaml"
+        owner: "root"
+        group: "root"
+        mode: 0644
+        content: |
+          autoupdate: true
+          command:
+            - --network=prater
+            - --logging=INFO
+            - --p2p-enabled=true
+            - --p2p-port=9001
+            - --validators-keystore-locking-enabled=false
+            - --validators-graffiti="stereum.net"
+            - --ee-endpoint=http://stereum-foobar:8551
+            - --ee-jwt-secret-file=/engine.jwt
+            - --validators-proposer-default-fee-recipient=0x0000000000000000000000000000000000000000
+            - --metrics-enabled=true
+            - --metrics-port=8008
+            - --metrics-interface=0.0.0.0
+            - --metrics-host-allowlist=*
+            - --metrics-publish-interval=10
+            - --metrics-categories=BEACON,LIBP2P,NETWORK,PROCESS
+            - --data-path=/opt/app/data
+            - --data-storage-mode=prune
+            - --rest-api-port=5051
+            - --rest-api-host-allowlist=*
+            - --rest-api-interface=0.0.0.0
+            - --rest-api-docs-enabled=true
+            - --rest-api-enabled=true
+            - --log-destination=CONSOLE
+            - --validator-api-enabled=true
+            - --validator-api-port=5052
+            - --validator-api-host-allowlist=*
+            - --validator-api-cors-origins=*
+            - --validator-api-keystore-file=/opt/app/data/teku_api_keystore
+            - --validator-api-keystore-password-file=/opt/app/data/teku_api_password.txt
+          configVersion: 1
+          dependencies:
+              consensusClients: []
+              executionClients:
+              -   id: dLYMYaf9-ovC0-CXOE-s3Cx-VJBUjjsXrrOS
+                  service: GethService
+              prometheusNodeExporterClients: []
+          entrypoint:
+          - /opt/teku/bin/teku
+          env:
+              JAVA_OPTS: -Xmx8g
+          id: 61cb4672-f069-4416-bf2a-db53a0776395
+          image: consensys/teku:22.9.0
+          network: prater
+          ports:
+          - 0.0.0.0:9001:9001/tcp
+          - 0.0.0.0:9001:9001/udp
+          restart_policy: null
+          service: TekuBeaconService
+          user: '2000'
+          volumes:
+            - /opt/stereum/teku-61cb4672-f069-4416-bf2a-db53a0776395/data:/opt/app/data
+      become: yes
+    
+    - name: create volume directory
+      file:
+        path: /opt/stereum/teku-61cb4672-f069-4416-bf2a-db53a0776395/data
+        state: directory
+      become: yes
+    
+    - name: create teku keystore password
+      copy:
+        content: "{{ lookup('password', '/dev/null', seed=inventory_hostname) }}"
+        dest: /opt/stereum/teku-61cb4672-f069-4416-bf2a-db53a0776395/data/teku_api_password.txt
+        force: no
+      become: yes
+
+    - name: create teku keystore dummy file
+      copy:
+        content: "dummy_keystore"
+        dest: /opt/stereum/teku-61cb4672-f069-4416-bf2a-db53a0776395/data/teku_api_keystore
+        force: no
+      become: yes
+
+    - name: Create Prysm service config
+      copy:
+        dest: "/etc/stereum/services/22272f4b-6652-b5da-f3b8-69d34a3ea784.yaml"
+        owner: "root"
+        group: "root"
+        mode: 0644
+        content: |
+          service: PrysmBeaconService
+          id: 22272f4b-6652-b5da-f3b8-69d34a3ea784
+          configVersion: 1
+          command: /app/cmd/beacon-chain/beacon-chain --accept-terms-of-use=true
+            --datadir=/opt/app/beacon --p2p-host-ip="" --p2p-host-dns="" --prater=true
+            --fallback-web3provider=http://foobar:8551 --block-batch-limit=512
+            --genesis-state=/opt/app/genesis/prysm-prater-genesis.ssz --rpc-host=0.0.0.0
+            --grpc-gateway-host=0.0.0.0 --p2p-max-peers=100
+            --http-web3provider=http://foobar:8551
+            --monitoring-host=0.0.0.0 --monitoring-port=8080 --p2p-tcp-port=13001
+            --p2p-udp-port=12001 --jwt-secret=/engine.jwt
+          entrypoint: []
+          env: {}
+          image: prysmaticlabs/prysm-beacon-chain:v3.1.1
+          ports:
+            - 0.0.0.0:13001:13001/tcp
+            - 0.0.0.0:12001:12001/udp
+            - 127.0.0.1:4000:4000/tcp
+          restart_policy: null
+          volumes:
+            - /opt/stereum/prysm-22272f4b-6652-b5da-f3b8-69d34a3ea784/beacon:/opt/app/beacon
+            - /opt/stereum/prysm-22272f4b-6652-b5da-f3b8-69d34a3ea784/genesis:/opt/app/genesis
+            - /opt/stereum/geth-b4c2019d-7116-17f8-7fa1-4e4be93105da/engine.jwt:/engine.jwt
+          user: "2000"
+          autoupdate: true
+          network: prater
+          dependencies:
+            executionClients:
+              - service: GethService
+                id: b4c2019d-7116-17f8-7fa1-4e4be93105da
+            consensusClients: []
+            prometheusNodeExporterClients: []
+      become: yes
+
+    - name: Create Geth service config
+      copy:
+        dest: "/etc/stereum/services/0dd89db9-a431-5e2f-81a4-b1c5d28ec220.yaml"
+        owner: "root"
+        group: "root"
+        mode: 0644
+        content: |
+          service: GethService
+          id: 0dd89db9-a431-5e2f-81a4-b1c5d28ec220
+          configVersion: 1
+          command:
+            - --goerli
+            - --datadir=/opt/data/geth
+            - --http
+            - --http.port=8545
+            - --http.addr=0.0.0.0
+            - --http.vhosts=*
+            - --http.api="engine,eth,web3,net,debug"
+            - --http.corsdomain=*
+            - --ws
+            - --ws.port=8546
+            - --ws.addr=0.0.0.0
+            - --ws.api="debug,eth,net,web3"
+            - --ws.origins=*
+            - --authrpc.port=8551
+            - --authrpc.addr=0.0.0.0
+            - --authrpc.vhosts=*
+            - --authrpc.jwtsecret=/engine.jwt
+            - --metrics
+            - --metrics.expensive
+            - --metrics.port=6060
+            - --metrics.addr=0.0.0.0
+          entrypoint:
+            - geth
+          env:
+            STEREUM_DUMMY: foobar
+          image: ethereum/client-go:v1.10.25
+          ports:
+            - 0.0.0.0:30303:30303/tcp
+            - 0.0.0.0:30303:30303/udp
+            - 127.0.0.1:8551:8551/tcp
+          restart_policy: null
+          volumes:
+            - /opt/stereum/geth-0dd89db9-a431-5e2f-81a4-b1c5d28ec220/data:/opt/data/geth
+            - /opt/stereum/geth-0dd89db9-a431-5e2f-81a4-b1c5d28ec220/engine.jwt:/engine.jwt
+          user: root
+          autoupdate: true
+          network: goerli
+          dependencies:
+            executionClients: []
+            consensusClients: []
+            prometheusNodeExporterClients: []
+            mevboost: []
+      become: yes
+
+    - name: Create Besu service config
+      copy:
+        dest: "/etc/stereum/services/7fabf678-eaac-ffe8-adaf-d081d71ddbe3.yaml"
+        owner: "root"
+        group: "root"
+        mode: 0644
+        content: |
+          service: BesuService
+          id: 7fabf678-eaac-ffe8-adaf-d081d71ddbe3
+          configVersion: 1
+          command:
+            - --network=goerli
+            - --data-path=/opt/app/data
+            - --data-storage-format=BONSAI
+            - --sync-mode=X_SNAP
+            - --p2p-port=30303
+            - --p2p-host=0.0.0.0
+            - --rpc-http-enabled=true
+            - --rpc-http-host=0.0.0.0
+            - --rpc-http-cors-origins=*
+            - --rpc-http-port=8545
+            - --rpc-ws-enabled=true
+            - --rpc-ws-host=0.0.0.0
+            - --rpc-ws-port=8546
+            - --host-allowlist=*
+            - --metrics-enabled
+            - --metrics-host=0.0.0.0
+            - --metrics-port=9545
+            - --logging=INFO
+            - --engine-rpc-enabled=true
+            - --engine-host-allowlist=*
+            - --engine-rpc-port=8551
+            - --engine-jwt-enabled=true
+            - --engine-jwt-secret=/engine.jwt
+            - --Xmerge-support=true
+          entrypoint:
+            - besu
+          env:
+            JAVA_OPTS: -Xmx4g
+          image: hyperledger/besu:22.7.6
+          ports:
+            - 0.0.0.0:30303:30303/tcp
+            - 0.0.0.0:30303:30303/udp
+            - 127.0.0.1:8551:8551/tcp
+          restart_policy: null
+          volumes:
+            - /opt/stereum/besu-7fabf678-eaac-ffe8-adaf-d081d71ddbe3/data:/opt/app/data
+            - /opt/stereum/besu-7fabf678-eaac-ffe8-adaf-d081d71ddbe3/engine.jwt:/engine.jwt
+          user: "2000"
+          autoupdate: true
+          network: goerli
+          dependencies:
+            executionClients: []
+            consensusClients: []
+            prometheusNodeExporterClients: []
+            mevboost:
+              - service: FlashbotsMevBoostService
+                id: 470fb37f-ad98-1ea7-f89e-e4a6b20cb3c0
+      become: yes
+
+# EOF

--- a/controls/roles/update-changes/molecule/20-rc9/verify.yml
+++ b/controls/roles/update-changes/molecule/20-rc9/verify.yml
@@ -1,0 +1,36 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+  # Teku
+  - name: Read teku service file
+    slurp:
+      src: "/etc/stereum/services/61cb4672-f069-4416-bf2a-db53a0776395.yaml"
+    register: teku_service_configuration_raw
+
+  - name: Parse teku service's configuration
+    set_fact: 
+      teku_service_configuration: "{{ teku_service_configuration_raw['content'] | b64decode | from_yaml }}"
+
+  - name: get keystore stat
+    stat:
+      path: "/opt/stereum/teku-61cb4672-f069-4416-bf2a-db53a0776395/data/teku_api_keystore"
+    register: teku_api_keystore
+
+  - debug:
+     msg: "{{ teku_api_keystore }}"
+
+  - debug:
+     msg: "{{ teku_service_configuration_raw['content'] | b64decode }}"
+
+  - assert:
+      that:
+      - (teku_service_configuration.command | select('match', "--validators-keystore-locking-enabled=false") | length) == 0
+      - (teku_service_configuration.command | select('match', "--validators-keystore-locking-enabled=true") | length) == 1
+      - teku_api_keystore.stat.exists
+  
+
+
+
+# EOF

--- a/controls/roles/update-changes/tasks/2.0-rc6/fix-prysm-822.yaml
+++ b/controls/roles/update-changes/tasks/2.0-rc6/fix-prysm-822.yaml
@@ -1,13 +1,23 @@
 ---
+- name: Read service file
+  slurp:
+    src: "{{ item.path }}"
+  register: service_configuration_raw
+
+- name: Parse service's configuration
+  set_fact:
+    service_configuration: "{{ service_configuration_raw['content'] | b64decode | from_yaml }}"
+
 - name: Remove fallback property
   replace:
     path: "{{ item.path }}"
     regexp: "--fallback-web3provider=.* "
+  when: service_configuration.service == "PrysmBeaconService"
 
 - name: Replace EE property
   replace:
     path: "{{ item.path }}"
     regexp: "http-web3provider"
     replace: "execution-endpoint"
-
+  when: service_configuration.service == "PrysmBeaconService"
 #EOF

--- a/controls/roles/update-changes/tasks/2.0-rc6/updates-20-rc6.yaml
+++ b/controls/roles/update-changes/tasks/2.0-rc6/updates-20-rc6.yaml
@@ -1,23 +1,13 @@
 ---
-- name: Fix prysm (config) PR 822
-  block:
-  - name: Find service configs
-    find:
-      paths: "/etc/stereum/services"
-      contains: ".*PrysmBeaconService.*"
-    register: prysm_config_files
+- name: Find service configs
+  find:
+    paths: "/etc/stereum/services"
+  register: service_config_files
 
-  - include_tasks: fix-prysm-822.yaml
-    loop: "{{ prysm_config_files.files }}"
+- include_tasks: fix-prysm-822.yaml
+  loop: "{{ service_config_files.files }}"
 
-- name: Adjust exposed ports PR 814
-  block:
-  - name: Find service configs
-    find:
-      paths: "/etc/stereum/services"
-    register: service_config_files
-  
-  - include_tasks: adjust-ports-814.yaml
-    loop: "{{ service_config_files.files }}"
+- include_tasks: adjust-ports-814.yaml
+  loop: "{{ service_config_files.files }}"
 
 #EOF

--- a/controls/roles/update-changes/tasks/2.0-rc7/updates-20-rc7.yaml
+++ b/controls/roles/update-changes/tasks/2.0-rc7/updates-20-rc7.yaml
@@ -1,27 +1,18 @@
 ---
-- name: Add mevboost dependency PR 869
-  block:
-  - name: Find service configs
-    find:
-      paths: "/etc/stereum/services"
-    register: service_config_files
 
-  - include_tasks: add-mevboost-dependency.yaml
-    loop: "{{ service_config_files.files }}"
+- name: Find service configs
+  find:
+    paths: "/etc/stereum/services"
+  register: service_config_files
 
-- name: Remove Besu Attribute
-  block:
-  - name: Find Besu Services
-    find:
-      paths: "/etc/stereum/services"
-      contains: ".*BesuService.*"
-    register: besu_config_files
+- include_tasks: add-mevboost-dependency.yaml
+  loop: "{{ service_config_files.files }}"
 
-  - name: Remove Xmerge Attribute
-    lineinfile:
-      path: "{{ item.path }}"
-      state: absent
-      regexp: '^\s*- --Xmerge-support=true'
-    with_items: "{{ besu_config_files.files }}"
+- name: Remove Xmerge Attribute
+  lineinfile:
+    path: "{{ item.path }}"
+    state: absent
+    regexp: '^\s*- --Xmerge-support=true'
+  with_items: "{{ service_config_files.files }}"
 
 #EOF

--- a/controls/roles/update-changes/tasks/2.0-rc9/teku_changes.yaml
+++ b/controls/roles/update-changes/tasks/2.0-rc9/teku_changes.yaml
@@ -1,0 +1,100 @@
+---
+- name: Read service file
+  slurp:
+    src: "{{ item.path }}"
+  register: service_configuration_raw
+
+- name: Parse service's configuration
+  set_fact:
+    service_configuration: "{{ service_configuration_raw['content'] | b64decode | from_yaml }}"
+    service_configuration_text: "{{ service_configuration_raw['content'] | b64decode }}"
+    
+- name: Set data dir path
+  set_fact:
+    service_configuration_data_path: "{{ service_configuration.volumes | select('match', '.*\/opt\/app\/data') | first | split(':') | first  }}"
+  when: service_configuration.service == "TekuBeaconService"
+
+- name: ensure dir exists
+  file:
+    path: "{{ service_configuration_data_path }}"
+    state: directory
+  become: yes
+  when: service_configuration.service == "TekuBeaconService"
+
+- name: Check if keystore file exists
+  stat: 
+    path: "{{ service_configuration_data_path }}/teku_api_keystore"
+  register: stat_teku_api_keystore
+  when: service_configuration.service == "TekuBeaconService"
+
+- name: Delete keystore file
+  file:
+    path: "{{ service_configuration_data_path }}/teku_api_keystore"
+    state: absent
+  when: service_configuration.service == "TekuBeaconService" and stat_teku_api_keystore.stat.exists
+  changed_when: false
+  become: yes
+
+- name: Check if password file exists
+  stat: 
+    path: "{{ service_configuration_data_path }}/teku_api_password.txt"
+  register: stat_teku_api_password
+  when: service_configuration.service == "TekuBeaconService"
+
+- name: Create the password file, if it doesnt exist already
+  copy:
+    content: "{{ lookup('password', '/dev/null', seed=inventory_hostname) }}"
+    dest: "{{ service_configuration_data_path }}/teku_api_password.txt"
+    force: no
+  when: service_configuration.service == "TekuBeaconService" and not stat_teku_api_password.stat.exists
+
+- name: Get teku-api password
+  slurp:
+    src: "{{ service_configuration_data_path }}/teku_api_password.txt"
+  register: teku_api_password
+  when: service_configuration.service == "TekuBeaconService"
+  become: yes
+
+- name: Set variable
+  set_fact:
+    api_password: "{{ teku_api_password['content'] | b64decode | trim }}"
+  when: service_configuration.service == "TekuBeaconService"
+
+- name: install keytool (Ubuntu)
+  apt:
+    update_cache: yes
+    name:
+      - openjdk-8-jre-headless
+    state: present
+  become: true
+  changed_when: false
+  when: service_configuration.service == "TekuBeaconService" and ansible_distribution == "Ubuntu"
+
+- name: install keytool (CentOS)
+  raw: yum install -y java-1.8.0-openjdk
+  become: true
+  changed_when: false
+  when: service_configuration.service == "TekuBeaconService" and ansible_distribution == "CentOS"
+
+- name: Create keystore file
+  command: bash -c "keytool -genkeypair
+                    -keystore teku_api_keystore
+                    -storetype PKCS12
+                    -storepass '{{ api_password }}'
+                    -keyalg RSA
+                    -keysize 2048
+                    -validity 109500
+                    -dname 'CN=teku, OU=MyCompanyUnit, O=MyCompany, L=MyCity, ST=MyState, C=AU'
+                    -ext 'SAN=DNS:stereum-{{ service_configuration.id }}'"
+  args:
+    chdir: "{{ service_configuration_data_path }}"
+  changed_when: false
+  when: service_configuration.service == "TekuBeaconService"
+  become: yes
+
+- name: set keystore locking
+  replace:
+    path: "{{ item.path }}"
+    regexp: "--validators-keystore-locking-enabled=false"
+    replace: "--validators-keystore-locking-enabled=true"
+  when: service_configuration.service == "TekuBeaconService"

--- a/controls/roles/update-changes/tasks/2.0-rc9/updates-20-rc9.yaml
+++ b/controls/roles/update-changes/tasks/2.0-rc9/updates-20-rc9.yaml
@@ -1,0 +1,13 @@
+---
+- name: Replace teku cert
+  block:
+  - name: Find service configs
+    find:
+      paths: "/etc/stereum/services"
+    register: service_config_files
+
+  - include_tasks: teku_changes.yaml
+    loop: "{{ service_config_files.files }}"
+
+
+#EOF

--- a/controls/roles/update-changes/tasks/main.yml
+++ b/controls/roles/update-changes/tasks/main.yml
@@ -8,4 +8,7 @@
 - include_tasks: "2.0-rc7/updates-20-rc7.yaml"
   ignore_errors: yes
 
+- include_tasks: "2.0-rc9/updates-20-rc9.yaml"
+  ignore_errors: yes
+
 # EOF

--- a/controls/roles/update-services/tasks/update-service.yml
+++ b/controls/roles/update-services/tasks/update-service.yml
@@ -17,7 +17,7 @@
 
 - name: Get latest version for this service
   set_fact:
-    new_service_docker_image_tag: "{{ update_data.json[service_configuration.network][service_configuration.service] | last }}"
+    new_service_docker_image_tag: "{{ update_data.json[service_configuration.network][service_configuration.service] | default(update_data.json['prater'][service_configuration.service]) | last }}"
   when: service_configuration.autoupdate
 
 - name: Build new image tag

--- a/controls/roles/validator-delete-api/molecule/teku/prepare.yml
+++ b/controls/roles/validator-delete-api/molecule/teku/prepare.yml
@@ -80,8 +80,8 @@
                           -keyalg RSA
                           -keysize 2048
                           -validity 109500
-                          -dname 'CN=localhost, OU=MyCompanyUnit, O=MyCompany, L=MyCity, ST=MyState, C=AU'
-                          -ext san=dns:localhost,ip:127.0.0.1"
+                          -dname 'CN=teku, OU=MyCompanyUnit, O=MyCompany, L=MyCity, ST=MyState, C=AU'
+                          -ext 'SAN=DNS:stereum-{{ beacon_service }}'"
         args:
           chdir: /opt/app/services/{{ beacon_service }}/data
         changed_when: false

--- a/controls/roles/validator-fee-recipient-api/molecule/teku/prepare.yml
+++ b/controls/roles/validator-fee-recipient-api/molecule/teku/prepare.yml
@@ -80,8 +80,8 @@
                           -keyalg RSA
                           -keysize 2048
                           -validity 109500
-                          -dname 'CN=localhost, OU=MyCompanyUnit, O=MyCompany, L=MyCity, ST=MyState, C=AU'
-                          -ext san=dns:localhost,ip:127.0.0.1"
+                          -dname 'CN=teku, OU=MyCompanyUnit, O=MyCompany, L=MyCity, ST=MyState, C=AU'
+                          -ext 'SAN=DNS:stereum-{{ beacon_service }}'"
         args:
           chdir: /opt/app/services/{{ beacon_service }}/data
         changed_when: false

--- a/controls/roles/validator-import-api/molecule/teku/prepare.yml
+++ b/controls/roles/validator-import-api/molecule/teku/prepare.yml
@@ -121,8 +121,8 @@
                           -keyalg RSA
                           -keysize 2048
                           -validity 109500
-                          -dname 'CN=localhost, OU=MyCompanyUnit, O=MyCompany, L=MyCity, ST=MyState, C=AU'
-                          -ext san=dns:localhost,ip:127.0.0.1"
+                          -dname 'CN=teku, OU=MyCompanyUnit, O=MyCompany, L=MyCity, ST=MyState, C=AU'
+                          -ext 'SAN=DNS:stereum-{{ beacon_service }}'"
         args:
           chdir: /opt/app/services/{{ beacon_service }}/data
         changed_when: false

--- a/controls/roles/validator-list-api/molecule/teku/prepare.yml
+++ b/controls/roles/validator-list-api/molecule/teku/prepare.yml
@@ -80,8 +80,8 @@
                           -keyalg RSA
                           -keysize 2048
                           -validity 109500
-                          -dname 'CN=localhost, OU=MyCompanyUnit, O=MyCompany, L=MyCity, ST=MyState, C=AU'
-                          -ext san=dns:localhost,ip:127.0.0.1"
+                          -dname 'CN=teku, OU=MyCompanyUnit, O=MyCompany, L=MyCity, ST=MyState, C=AU'
+                          -ext 'SAN=DNS:stereum-{{ beacon_service }}'"
         args:
           chdir: /opt/app/services/{{ beacon_service }}/data
         changed_when: false

--- a/launcher/src/backend/OneClickInstall.js
+++ b/launcher/src/backend/OneClickInstall.js
@@ -224,7 +224,7 @@ export class OneClickInstall {
       await this.nodeConnection.sshService.exec('apt install -y openjdk-8-jre-headless')
       await this.nodeConnection.sshService.exec(`mkdir -p ${dataDir}`)
       await this.nodeConnection.sshService.exec(`echo ${password} > ${dataDir}/teku_api_password.txt`)
-      await this.nodeConnection.sshService.exec(`cd ${dataDir} && keytool -genkeypair -keystore teku_api_keystore -storetype PKCS12 -storepass ${password} -keyalg RSA -keysize 2048 -validity 109500 -dname 'CN=localhost, OU=MyCompanyUnit, O=MyCompany, L=MyCity, ST=MyState, C=AU' -ext san=dns:localhost,ip:127.0.0.1`)
+      await this.nodeConnection.sshService.exec(`cd ${dataDir} && keytool -genkeypair -keystore teku_api_keystore -storetype PKCS12 -storepass ${password} -keyalg RSA -keysize 2048 -validity 109500 -dname "CN=teku, OU=MyCompanyUnit, O=MyCompany, L=MyCity, ST=MyState, C=AU" -ext "SAN=DNS:stereum-${this.beaconService.id}"`)
     }
 
     if (constellation.includes('SSVNetworkService')) {

--- a/launcher/src/backend/ServiceManager.js
+++ b/launcher/src/backend/ServiceManager.js
@@ -519,7 +519,7 @@ export class ServiceManager {
         await this.nodeConnection.sshService.exec('apt install -y openjdk-8-jre-headless')
         await this.nodeConnection.sshService.exec(`mkdir -p ${dataDir}`)
         await this.nodeConnection.sshService.exec(`echo ${password} > ${dataDir}/teku_api_password.txt`)
-        await this.nodeConnection.sshService.exec(`cd ${dataDir} && keytool -genkeypair -keystore teku_api_keystore -storetype PKCS12 -storepass ${password} -keyalg RSA -keysize 2048 -validity 109500 -dname 'CN=localhost, OU=MyCompanyUnit, O=MyCompany, L=MyCity, ST=MyState, C=AU' -ext san=dns:localhost,ip:127.0.0.1`)
+        await this.nodeConnection.sshService.exec(`cd ${dataDir} && keytool -genkeypair -keystore teku_api_keystore -storetype PKCS12 -storepass ${password} -keyalg RSA -keysize 2048 -validity 109500 -dname "CN=teku, OU=MyCompanyUnit, O=MyCompany, L=MyCity, ST=MyState, C=AU" -ext "SAN=DNS:stereum-${service.id}"`)
       }
     }
   }

--- a/launcher/src/backend/ethereum-services/TekuBeaconService.int.js
+++ b/launcher/src/backend/ethereum-services/TekuBeaconService.int.js
@@ -95,7 +95,7 @@ test('teku validator import', async () => {
     const password = StringUtils.createRandomString()
     await nodeConnection.sshService.exec('apt install -y openjdk-8-jre-headless')
     await nodeConnection.sshService.exec(`echo ${password} > ${dataDir}/teku_api_password.txt`)
-    await nodeConnection.sshService.exec(`cd ${dataDir} && keytool -genkeypair -keystore teku_api_keystore -storetype PKCS12 -storepass ${password} -keyalg RSA -keysize 2048 -validity 109500 -dname 'CN=localhost, OU=MyCompanyUnit, O=MyCompany, L=MyCity, ST=MyState, C=AU' -ext san=dns:localhost,ip:127.0.0.1`)
+    await nodeConnection.sshService.exec(`cd ${dataDir} && keytool -genkeypair -keystore teku_api_keystore -storetype PKCS12 -storepass ${password} -keyalg RSA -keysize 2048 -validity 109500 -dname "CN=teku, OU=MyCompanyUnit, O=MyCompany, L=MyCity, ST=MyState, C=AU" -ext "SAN=DNS:stereum-${tekuClient.id}"`)
 
     await serviceManager.manageServiceState(tekuClient.id, 'stopped')
     await serviceManager.manageServiceState(tekuClient.id, 'started')

--- a/launcher/src/components/UI/the-staking/DisplayValidators.vue
+++ b/launcher/src/components/UI/the-staking/DisplayValidators.vue
@@ -1228,6 +1228,7 @@ remove-validator {
 
 .import-message span {
   width: 90%;
+  height: 90%;
   margin: 0 auto;
   color: rgb(156, 156, 156);
   font-size: 1rem;


### PR DESCRIPTION
### Update Teku Certs fixes #958 
This PR includes a rollout in form of a `update-changes` role and fixes this problem for all future fresh installs of teku

### Fix `update-services`
This PR also fixes update-services. it used to fail when a service config included a network which was not defined in updates.json. (e.g. `goerli.LighthouseBeaconService` would not be defined)

### UI Adjustments
When a validator import fails and the api response doesn't include an error code nor an error message, the whole msg is displayed to avoid something like : `Validator Import Failed: undefined undefined`

### Fix `update-changes`
update-changes was looking for files that include the service name (e.g. `LighthouseBeaconService`) this caused files that included this string in their dependencies also to be included. fixed this by specificly checking for `service_config.service`

