### PR TITLE
REFACTOR: prevent nodatalayer on first load in p2p- and syncstatus widget

### DIFF
--- a/launcher/src/components/UI/the-control/PeerToPeer.vue
+++ b/launcher/src/components/UI/the-control/PeerToPeer.vue
@@ -8,7 +8,7 @@
         <span>PEER NETWORK</span>
       </div>
       <div class="wrapper">
-        <no-data v-if="!p2pItemsShow"></no-data>
+        <no-data v-if="noDataLayerShow"></no-data>
         <div class="p2pBarBox" v-show="p2pItemsShow">
           <div class="p2pBarCont">
             <div class="titleVal">
@@ -66,6 +66,7 @@ export default {
       isMultiService: false,
       p2pItemsShow: false,
       p2pIcoUnknown: true,
+      noDataLayerShow: false,
       consensusClient: "CC",
       consensusNumPeer: "100",
       consensusValPeer: "0",
@@ -176,6 +177,7 @@ export default {
             if (this.p2pstatus.data.error == "prometheus service not running") {
               this.p2pItemsShow = false;
               this.p2pIcoUnknown = true;
+              this.noDataLayerShow = true;
               //this.pageNumber = 1;
               //this.isMultiService = false;
             }
@@ -187,6 +189,7 @@ export default {
       let isMultiService = false;
       let p2pItemsShow = false;
       let p2pIcoUnknown = true;
+      let noDataLayerShow = false;
       let consensusClient = this.consensusClient;
       let consensusNumPeer = this.consensusNumPeer;
       let consensusValPeer = this.consensusValPeer;
@@ -215,6 +218,7 @@ export default {
       this.isMultiService = isMultiService;
       this.p2pItemsShow = p2pItemsShow;
       this.p2pIcoUnknown = p2pIcoUnknown;
+      this.noDataLayerShow = noDataLayerShow;
       this.consensusClient = consensusClient;
       this.consensusNumPeer = consensusNumPeer;
       this.consensusValPeer = consensusValPeer;

--- a/launcher/src/components/UI/the-control/SyncStatus.vue
+++ b/launcher/src/components/UI/the-control/SyncStatus.vue
@@ -9,7 +9,7 @@
       </div>
       <!-- <no-data></no-data> -->
       <div class="wrapper">
-        <no-data v-if="!syncItemsShow"></no-data>
+        <no-data v-if="noDataLayerShow"></no-data>
         <div class="sync-box_value" v-if="syncItemsShow">
           <div
             v-for="item in clients"
@@ -61,6 +61,7 @@ export default {
       syncIcoUnknown: true,
       syncIcoSituation: false,
       syncIcoError: false,
+      noDataLayerShow: false,
       prysm: "",
       geth: "",
       lighthaouse: "",
@@ -194,6 +195,7 @@ export default {
               this.syncIcoUnknown = true;
               this.syncIcoError = false;
               this.syncIcoSituation = false;
+              this.noDataLayerShow = true;
               //this.pageNumber = 1;
               //this.clients = [];
               //this.isMultiService = false;
@@ -209,6 +211,7 @@ export default {
       let syncIcoUnknown = true;
       let syncIcoError = false;
       let syncIcoSituation = false;
+      let noDataLayerShow = false;
       let fonts = {
         red: [], // client error (for example docker container not running) - icon red
         orange: [], // abnormal client data during init (for example: lowerslot > higherslot) - icon unknown
@@ -276,6 +279,7 @@ export default {
       this.pageNumber = pageNum;
       this.clients = clients;
       this.isMultiService = isMultiService;
+      this.noDataLayerShow = noDataLayerShow;
       this.refresh();
     },
   },

--- a/launcher/src/components/UI/the-control/SyncStatus.vue
+++ b/launcher/src/components/UI/the-control/SyncStatus.vue
@@ -7,7 +7,6 @@
         </div>
         <span>{{ $t("controlPage.syncStatus") }}</span>
       </div>
-      <!-- <no-data></no-data> -->
       <div class="wrapper">
         <no-data v-if="noDataLayerShow"></no-data>
         <div class="sync-box_value" v-if="syncItemsShow">
@@ -62,10 +61,6 @@ export default {
       syncIcoSituation: false,
       syncIcoError: false,
       noDataLayerShow: false,
-      prysm: "",
-      geth: "",
-      lighthaouse: "",
-      teko: "",
       syncIco: [
         {
           id: 1,


### PR DESCRIPTION
- Made sure that the NoDataLayer is only shown after the widget has at least one time successfully initialized
- Cleaned dead code from SyncStatus Widget