### PR TITLE
ADD: Restart after initial Setup

### DIFF
--- a/launcher/package-lock.json
+++ b/launcher/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stereum-launcher",
-  "version": "2.0.0-rc.8",
+  "version": "2.0.0-rc.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stereum-launcher",
-      "version": "2.0.0-rc.8",
+      "version": "2.0.0-rc.9",
       "license": "https://wrapbootstrap.com/help/licenses",
       "dependencies": {
         "@babel/core": "^7.16.7",

--- a/launcher/src/background.js
+++ b/launcher/src/background.js
@@ -380,6 +380,10 @@ promiseIpc.on("prepareStereumNode", async (arg) => {
   return 0
 });
 
+promiseIpc.on("restartServer", async () => {
+  return await nodeConnection.restartServer()
+});
+
 // Scheme must be registered before the app is ready
 protocol.registerSchemesAsPrivileged([
   { scheme: "app", privileges: { secure: true, standard: true } },

--- a/launcher/src/components/UI/custom-installation/CustomInstallationLayer.vue
+++ b/launcher/src/components/UI/custom-installation/CustomInstallationLayer.vue
@@ -40,6 +40,7 @@
 import ControlService from "@/store/ControlService";
 import { mapWritableState } from "pinia";
 import { useNodeManage } from "@/store/nodeManage";
+import { useNodeHeader } from "@/store/nodeHeader";
 export default {
   data() {
     return {
@@ -54,11 +55,18 @@ export default {
       currentNetwork: "currentNetwork",
       networkList: "networkList",
     }),
+    ...mapWritableState(useNodeHeader, {
+      refresh: "refresh",
+    }),
   },
   methods: {
     async prepareStereum(){
       this.currentNetwork = this.networkList.find(item => item.network === "testnet")
+      this.refresh = false
       await ControlService.prepareStereumNode(this.installPath);
+      if(await ControlService.restartServer())
+        await new Promise(resolve => setTimeout(resolve, 20000))      
+      this.refresh = true
     },
     activeBtn() {
       if (this.installPath === "") {

--- a/launcher/src/components/UI/custom-installation/CustomInstallationLayer.vue
+++ b/launcher/src/components/UI/custom-installation/CustomInstallationLayer.vue
@@ -64,9 +64,10 @@ export default {
       this.currentNetwork = this.networkList.find(item => item.network === "testnet")
       this.refresh = false
       await ControlService.prepareStereumNode(this.installPath);
-      if(await ControlService.restartServer())
-        await new Promise(resolve => setTimeout(resolve, 20000))      
+      const restarted = await ControlService.restartServer()
       this.refresh = true
+      if(restarted)
+        await new Promise(resolve => setTimeout(resolve, 20000))      
     },
     activeBtn() {
       if (this.installPath === "") {

--- a/launcher/src/components/UI/node-header/MainNavbar.vue
+++ b/launcher/src/components/UI/node-header/MainNavbar.vue
@@ -57,8 +57,8 @@ export default {
   methods: {
     refreshServiceStates: async function () {
       const allServices = JSON.parse(JSON.stringify(this.allServices));
-      if (await this.checkConnection()) {
-        if (this.refresh) {
+      if (this.refresh) {
+        if (await this.checkConnection()) {
           let services = await ControlService.refreshServiceInfos();
           if (services && services.length != 0 && this.refresh) {
             let otherServices = [];

--- a/launcher/src/components/UI/plugin-installation/VerifyInstallation.vue
+++ b/launcher/src/components/UI/plugin-installation/VerifyInstallation.vue
@@ -93,6 +93,7 @@ export default {
     }),
     ...mapWritableState(useNodeHeader, {
       headerServices: "runningServices",
+      refresh: "refresh",
     }),
   },
   mounted() {
@@ -104,7 +105,11 @@ export default {
     runInstalltion: async function () {
       this.$router.push("/node");
       this.displayInstallationWarning = false;
+      this.refresh = false
       await ControlService.prepareOneClickInstallation(this.installationPath);
+      if(await ControlService.restartServer())
+        await new Promise(resolve => setTimeout(resolve, 20000))
+      this.refresh = true
       await ControlService.writeOneClickConfiguration({
         services: this.selectedPreset.includedPlugins,
         checkpointURL: this.checkPointSync,

--- a/launcher/src/components/UI/plugin-installation/VerifyInstallation.vue
+++ b/launcher/src/components/UI/plugin-installation/VerifyInstallation.vue
@@ -107,9 +107,10 @@ export default {
       this.displayInstallationWarning = false;
       this.refresh = false
       await ControlService.prepareOneClickInstallation(this.installationPath);
-      if(await ControlService.restartServer())
-        await new Promise(resolve => setTimeout(resolve, 20000))
+      const restarted = await ControlService.restartServer()
       this.refresh = true
+      if(restarted)
+        await new Promise(resolve => setTimeout(resolve, 20000))
       await ControlService.writeOneClickConfiguration({
         services: this.selectedPreset.includedPlugins,
         checkpointURL: this.checkPointSync,

--- a/launcher/src/pages/TheNode.vue
+++ b/launcher/src/pages/TheNode.vue
@@ -162,20 +162,15 @@ export default {
     ...mapWritableState(useControlStore, {
       ServerName: "ServerName",
       ipAddress: "ipAddress",
-      cpu: "cpu",
-      availDisk: "availDisk",
-      usedPerc: "usedPerc",
     }),
   },
   mounted() {
     this.updateConnectionStats();
     this.updateServiceLogs();
     this.polling = setInterval(this.updateServiceLogs, 10000); // refresh logs
-    this.pollingVitals = setInterval(this.updateServerVitals, 1000); // refresh server vitals
   },
   beforeUnmount() {
     clearInterval(this.polling);
-    clearInterval(this.pollingVitals);
   },
   methods: {
     sortByName(a, b) {
@@ -193,15 +188,10 @@ export default {
       this.ipAddress = stats.ipAddress;
     },
     async updateServiceLogs() {
-      const data = await ControlService.getServiceLogs();
-      this.serviceLogs = data;
-    },
-    async updateServerVitals() {
-      const data = await ControlService.getServerVitals();
-      this.serverVitals = data;
-      this.cpu = this.serverVitals.cpu;
-      this.availDisk = this.serverVitals.availDisk;
-      this.usedPerc = this.serverVitals.usedPerc;
+      if(this.installedServices && this.installedServices.length){
+        const data = await ControlService.getServiceLogs();
+        this.serviceLogs = data;
+      }
     },
     showModal(data) {
       this.isModalActive = true;

--- a/launcher/src/pages/TheNode.vue
+++ b/launcher/src/pages/TheNode.vue
@@ -120,6 +120,7 @@ import TheVideos from "../components/UI/tutorial-steps/TheVideos.vue";
 import TutorialModal from "../components/UI/tutorial-steps/TutorialModal.vue";
 import NodeAlert from "../components/UI/the-node/NodeAlert.vue";
 import NodeTutorial from "../components/UI/the-node/NodeTutorial.vue";
+import { useNodeHeader } from "../store/nodeHeader";
 
 export default {
   components: {
@@ -162,15 +163,23 @@ export default {
     ...mapWritableState(useControlStore, {
       ServerName: "ServerName",
       ipAddress: "ipAddress",
+      cpu: "cpu",
+      availDisk: "availDisk",
+      usedPerc: "usedPerc",
     }),
+    ...mapWritableState(useNodeHeader, {
+      refresh: "refresh",
+    })
   },
   mounted() {
     this.updateConnectionStats();
     this.updateServiceLogs();
     this.polling = setInterval(this.updateServiceLogs, 10000); // refresh logs
+    this.pollingVitals = setInterval(this.updateServerVitals, 1000); // refresh server vitals
   },
   beforeUnmount() {
     clearInterval(this.polling);
+    clearInterval(this.pollingVitals);
   },
   methods: {
     sortByName(a, b) {
@@ -188,9 +197,18 @@ export default {
       this.ipAddress = stats.ipAddress;
     },
     async updateServiceLogs() {
-      if(this.installedServices && this.installedServices.length){
+      if(this.installedServices && this.installedServices.length > 0){
         const data = await ControlService.getServiceLogs();
         this.serviceLogs = data;
+      }
+    },
+    async updateServerVitals() {
+      if(this.installedServices && this.installedServices.length > 0){
+        const data = await ControlService.getServerVitals();
+        this.serverVitals = data;
+        this.cpu = this.serverVitals.cpu;
+        this.availDisk = this.serverVitals.availDisk;
+        this.usedPerc = this.serverVitals.usedPerc;
       }
     },
     showModal(data) {

--- a/launcher/src/store/ControlService.js
+++ b/launcher/src/store/ControlService.js
@@ -292,6 +292,10 @@ class ControlService extends EventEmitter {
   async prepareStereumNode(args){
     return await this.promiseIpc.send("prepareStereumNode", args);
   }
+
+  async restartServer(){
+    return await this.promiseIpc.send("restartServer");
+  }
 }
 if (!instance) {
   instance = new ControlService(window.electron);


### PR DESCRIPTION
This checks for a requireed restart and restarts accordingly.
Optimised refresh loops to prevent errors while connection cuts when the node restarts.
closes #413 