### PR TITLE
FIX: Erigon Config

### DIFF
--- a/controls/roles/manage-service/molecule/erigon-lodestar/converge.yml
+++ b/controls/roles/manage-service/molecule/erigon-lodestar/converge.yml
@@ -37,6 +37,7 @@
                 - --authrpc.vhosts=*
                 - --authrpc.jwtsecret=/engine.jwt
                 - --prune=htc
+                - --externalcl
                 - --ws
                 - --http
                 - --http.vhosts=*

--- a/controls/roles/manage-service/molecule/erigon-lodestar/verify.yml
+++ b/controls/roles/manage-service/molecule/erigon-lodestar/verify.yml
@@ -13,4 +13,14 @@
     retries: 60
     delay: 10
 
+  #  Erigon Service logs
+  - name: Erigon Service
+    command: "docker logs stereum-1d938f4c-3540-11ed-b4fd-f72a7f412029"
+    register: erigon_logs
+    until:
+      - erigon_logs.stderr is search("HTTP endpoint opened for Engine API")
+      - erigon_logs.stderr is search("Started P2P networking")
+    retries: 60
+    delay: 10
+
 # EOF

--- a/launcher/src/backend/ethereum-services/ErigonService.js
+++ b/launcher/src/backend/ethereum-services/ErigonService.js
@@ -31,6 +31,7 @@ export class ErigonService extends NodeService {
         `--authrpc.port=8551`,
         `--authrpc.jwtsecret=/engine.jwt`,
         `--prune=htc`,
+        `--externalcl`,
         `--ws`,
         `--http`,
         `--http.vhosts=*`,


### PR DESCRIPTION
Erigon changed their default behaviour:

### Embedded Consensus Layer

By default the Engine API is disabled in favour of Erigon native Embedded Consensus Layer, if you want to either stake or sync an external Consensus Layer, run Erigon with flag `--externalcl`.