### PR TITLE
FIX: Bootnodes only for gnosis

### DIFF
--- a/launcher/src/backend/ethereum-services/LighthouseBeaconService.js
+++ b/launcher/src/backend/ethereum-services/LighthouseBeaconService.js
@@ -41,7 +41,6 @@ export class LighthouseBeaconService extends NodeService {
         'bn',
         '--debug-level=info',
         `--network=${network}`,
-        `--boot-nodes=${CL_BootNodes.join()}`,
         `--execution-endpoint=${eth1Nodes}`,
         `--execution-jwt=${JWTDir}`,
         '--eth1-blocks-per-log-query=150',
@@ -72,6 +71,8 @@ export class LighthouseBeaconService extends NodeService {
       service.command.push('--checkpoint-sync-url=' + checkpointURL)
     if(mevboostEndpoint)
       service.command.push(`--builder=${mevboostEndpoint}`)
+    if(network == "gnosis")
+      service.command.push(`--boot-nodes=${CL_BootNodes.join()}`)
 
     return service
   }

--- a/launcher/src/backend/ethereum-services/TekuBeaconService.js
+++ b/launcher/src/backend/ethereum-services/TekuBeaconService.js
@@ -41,7 +41,6 @@ export class TekuBeaconService extends NodeService {
                 '--logging=INFO',
                 '--p2p-enabled=true',
                 '--p2p-port=9001',
-                `--p2p-discovery-bootnodes=${CL_BootNodes.join()}`,
                 '--validators-keystore-locking-enabled=true',
                 `--validators-graffiti-file=${graffitiDir}/graffitis.yaml`,
                 //`--eth1-endpoints=${executionLayer}`,
@@ -86,6 +85,8 @@ export class TekuBeaconService extends NodeService {
             service.command.push('--initial-state=' + checkpointURL)
         if(mevboostEndpoint)
             service.command.push(`--builder-endpoint=${mevboostEndpoint}`)
+        if(network == "gnosis")
+            service.command.push(`--p2p-discovery-bootnodes=${CL_BootNodes.join()}`)
         return service
     }
 


### PR DESCRIPTION
I made a mistake and added the gnosis bootnodes to the main config of Lighthouse and Teku.
Bootnodes are now only added when the configured network is `gnosis`