### PR TITLE
UPDATE: Nethermind, qol changes

### DIFF
--- a/.github/workflows/test-molecule.yml
+++ b/.github/workflows/test-molecule.yml
@@ -71,6 +71,7 @@ jobs:
           {role: "update-changes", test: "20-rc7"},
           {role: "update-changes", test: "20-rc9"},
           {role: "update-changes", test: "20-rc10"}
+          {role: "update-changes", test: "20-rc12"}
         ]
       fail-fast: false
     concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}

--- a/controls/defaults/stereum_defaults.yaml
+++ b/controls/defaults/stereum_defaults.yaml
@@ -10,17 +10,17 @@ stereum_static:
         install: false
     versions:
       # consensus clients
-      lighthouse:  v3.2.1
-      nimbus: multiarch-v22.12.0
+      lighthouse:  v3.4.0
+      nimbus: multiarch-v23.1.0
       teku: "22.12.0"
-      prysm: v3.1.2
-      lodestar: v1.2.1
+      prysm: v3.2.0
+      lodestar: v1.3.0
 
       # execution clients
       geth: v1.10.26
-      besu: "22.10.0"
-      nethermind: "1.14.6"
-      erigon: v2.30.0
+      besu: "22.10.3"
+      nethermind: "1.16.1"
+      erigon: v2.36.1
 
       # mevboost
       mevboost: v1.4.0
@@ -30,9 +30,9 @@ stereum_static:
 
       # tools
       curl: "7.85.0"
-      grafana: "9.2.5"
+      grafana: "9.3.2"
       node_exporter: v1.4.0
-      prometheus:  v2.40.2
+      prometheus:  v2.41.0
       notifications: v1.1.0
 
     # mevboost - relay

--- a/controls/roles/manage-service/molecule/mevboost-erigon-lodestar/converge.yml
+++ b/controls/roles/manage-service/molecule/mevboost-erigon-lodestar/converge.yml
@@ -112,7 +112,7 @@
                 - validator
                 - --network=goerli
                 - --dataDir=/opt/app/validator
-                - --beaconNodes==http://stereum-{{ lodestar_beacon_service }}:9596
+                - --beaconNodes=http://stereum-{{ lodestar_beacon_service }}:9596
                 - --suggestedFeeRecipient=0x5dC29815e46dfb5EAb5C57606f8e2A5FbBdb454e
                 - --keymanager
                 - --builder=true

--- a/controls/roles/manage-service/molecule/nethermind-teku-gnosis/converge.yml
+++ b/controls/roles/manage-service/molecule/nethermind-teku-gnosis/converge.yml
@@ -30,7 +30,7 @@
               entrypoint: ["./Nethermind.Runner"]
               env: {}
               command:
-              - --config=xdai
+              - --config=gnosis
               - --log=debug
               - --datadir=/opt/app/data
               - --Network.DiscoveryPort=30303

--- a/controls/roles/update-changes/molecule/20-rc12/verify.yml
+++ b/controls/roles/update-changes/molecule/20-rc12/verify.yml
@@ -17,9 +17,9 @@
   - debug:
       msg: "{{ node_exporter_service_configuration }}"
 
-  # - assert:
-  #     that:
-  #     - (node_exporter_service_configuration.command | select('match', '--path.rootfs=/host') | length) == 1
-  #     - (node_exporter_service_configuration.volumes | select('match', '/:/host:ro,rslave') | length) == 1
+  - assert:
+      that:
+      - (node_exporter_service_configuration.command | select('match', '--path.rootfs=/host') | length) == 1
+      - (node_exporter_service_configuration.volumes | select('match', '/:/host:ro,rslave') | length) == 1
 
 # EOF

--- a/controls/roles/update-changes/tasks/main.yml
+++ b/controls/roles/update-changes/tasks/main.yml
@@ -14,7 +14,7 @@
 - include_tasks: "2.0-rc10/updates-20-rc10.yaml"
   ignore_errors: yes
 
-# - include_tasks: "2.0-rc12/updates-20-rc12.yaml"
-#   ignore_errors: yes
+- include_tasks: "2.0-rc12/updates-20-rc12.yaml"
+  ignore_errors: yes
 
 # EOF

--- a/controls/roles/validator-delete-api/molecule/lodestar/prepare.yml
+++ b/controls/roles/validator-delete-api/molecule/lodestar/prepare.yml
@@ -106,7 +106,7 @@
                 - validator
                 - --network=goerli
                 - --dataDir=/opt/app/validator
-                - --beaconNodes==http://stereum-{{ beacon_service }}:9596
+                - --beaconNodes=http://stereum-{{ beacon_service }}:9596
                 - --keymanager
                 - --keymanager.address=0.0.0.0
                 - --keymanager.port=5062

--- a/controls/roles/validator-fee-recipient-api/molecule/lodestar/prepare.yml
+++ b/controls/roles/validator-fee-recipient-api/molecule/lodestar/prepare.yml
@@ -107,7 +107,7 @@
                 - validator
                 - --network=goerli
                 - --dataDir=/opt/app/validator
-                - --beaconNodes==http://stereum-{{ beacon_service }}:9596
+                - --beaconNodes=http://stereum-{{ beacon_service }}:9596
                 - --keymanager
                 - --keymanager.port=5062
                 - --keymanager.address=0.0.0.0

--- a/controls/roles/validator-import-api/molecule/lodestar/prepare.yml
+++ b/controls/roles/validator-import-api/molecule/lodestar/prepare.yml
@@ -91,7 +91,7 @@
                 - validator
                 - --network=goerli
                 - --dataDir=/opt/app/validator
-                - --beaconNodes==http://stereum-{{ beacon_service }}:9596
+                - --beaconNodes=http://stereum-{{ beacon_service }}:9596
                 - --keymanager
                 - --keymanager.address=0.0.0.0
                 - --keymanager.port=5062

--- a/controls/roles/validator-list-api/molecule/lodestar/prepare.yml
+++ b/controls/roles/validator-list-api/molecule/lodestar/prepare.yml
@@ -100,7 +100,7 @@
                 - validator
                 - --network=goerli
                 - --dataDir=/opt/app/validator
-                - --beaconNodes==http://stereum-{{ beacon_service }}:9596
+                - --beaconNodes=http://stereum-{{ beacon_service }}:9596
                 - --keymanager
                 - --keymanager.address=0.0.0.0
                 - --keymanager.port=5062

--- a/launcher/src/backend/OneClickInstall.js
+++ b/launcher/src/backend/OneClickInstall.js
@@ -153,7 +153,6 @@ export class OneClickInstall {
 
     if (constellation.includes('FlashbotsMevBoostService')) {
       //FlashbotsMevBoostService
-      log.info(relayURL)
       this.mevboost = FlashbotsMevBoostService.buildByUserInput(this.networkHandler(), relayURL)
     }
 
@@ -288,6 +287,8 @@ export class OneClickInstall {
       this.prometheus.imageVersion = this.getLatestVersion(versions, this.prometheus)
       this.prometheusNodeExporter.imageVersion = this.getLatestVersion(versions, this.prometheusNodeExporter)
       this.grafana.imageVersion = this.getLatestVersion(versions, this.grafana)
+      if (this.mevboost)
+        this.mevboost.imageVersion = this.getLatestVersion(versions, this.mevboost)
       if (this.validatorService) {
         this.validatorService.imageVersion = this.getLatestVersion(versions, this.validatorService)
       }

--- a/launcher/src/backend/ethereum-services/NethermindService.js
+++ b/launcher/src/backend/ethereum-services/NethermindService.js
@@ -19,9 +19,9 @@ export class NethermindService extends NodeService {
             service.id,             // id
             1,                      // configVersion
             'nethermind/nethermind',// image
-            '1.15.0',               // imageVersion
+            '1.16.1',               // imageVersion
             [
-                `--config=${network === "gnosis" ? "xdai" : network}`,
+                `--config=${network}`,
                 '--log=info',
                 `--datadir=${dataDir}`,
                 '--Network.DiscoveryPort=30303',

--- a/launcher/src/components/UI/node-manage/AddPanel.vue
+++ b/launcher/src/components/UI/node-manage/AddPanel.vue
@@ -168,6 +168,7 @@ import { mapWritableState } from "pinia";
 import { useServices } from "@/store/services";
 import { useNodeManage } from "../../../store/nodeManage";
 import { toRaw } from "vue";
+import ControlService from "@/store/ControlService";
 
 export default {
   props: ["items"],
@@ -208,6 +209,9 @@ export default {
       immediate: true,
     },
   },
+  mounted(){
+    this.getInstallPath()
+  },
   methods: {
     switchHandler(service) {
       if (service.selectedForConnection) {
@@ -240,6 +244,13 @@ export default {
           .map((r) => r[this.configNetwork.network.toLowerCase()])
           .join(),
       });
+    },
+    getInstallPath: async function () {
+      let largestVolumePath = await ControlService.getLargestVolumePath();
+      if(largestVolumePath = '/')
+        largestVolumePath = largestVolumePath + 'opt'
+      const stereumInstallationPath = [largestVolumePath, '/stereum'].join('/').replace(/\/{2,}/, '/');
+      this.installationPath = stereumInstallationPath;
     },
     changeResyncOptions() {
       if (this.genesisIsActive) {

--- a/launcher/src/components/UI/plugin-installation/PluginName.vue
+++ b/launcher/src/components/UI/plugin-installation/PluginName.vue
@@ -316,9 +316,10 @@ export default {
       }
     },
     getInstallPath: async function () {
-      const largestVolumePath = await ControlService.getLargestVolumePath();
+      let largestVolumePath = await ControlService.getLargestVolumePath();
+      if(largestVolumePath = '/')
+        largestVolumePath = largestVolumePath + 'opt'
       const stereumInstallationPath = [largestVolumePath, '/stereum'].join('/').replace(/\/{2,}/, '/');
-
       this.installationPath = stereumInstallationPath;
     }
   },


### PR DESCRIPTION
## Nethermind -> `1.16.1`
new gnosis nodes will use `gnosis` instead of `xdai`

## Failing Lodestar tests
mistake in the service config

## Choose Path of Largest Volume
if the path of the largest volume was the root dir the install directory ended up with `/stereum`
changed to `/opt/stereum` when path of largest volume equals `/`.

## Custom Installation
chooses path of largest volume when installing via custom installation

## MEV Boost OneClickInstaller
the right image version is now queried

## Prometheus Node Exporter
readded update-changes script and tests for next release