### PR TITLE
REFACTOR: Add Erigon EL to Dashboard Widgets and Lodestar CL fixes

### DIFF
--- a/launcher/src/backend/ethereum-services/ErigonService.js
+++ b/launcher/src/backend/ethereum-services/ErigonService.js
@@ -38,7 +38,7 @@ export class ErigonService extends NodeService {
         `--http.corsdomain=*`,
         `--http.addr=0.0.0.0`,
         `--http.port=8545`,
-        `--http.api=engine,net,eth`,
+        `--http.api=engine,net,eth,web3`,
         `--metrics`,
         `--metrics.addr=0.0.0.0`,
         `--metrics.port=6060`,


### PR DESCRIPTION
### Erigon
- Implemented Erigon EL to SyncStatus, P2PStatus and DATA-API Widgets
### Lodestar
- Corrected the label to query peers for P2PStatus Widget
- Added +10% to maximum allowed peers (--targetPeers) for P2PStatus Widget
### General
- Added possibility to get chain head value for EL from RPC API (currently used by Erigon, possible for all clients)