### PR TITLE
FIX: tunnel issue

### DIFF
--- a/launcher/src/backend/SSHService.js
+++ b/launcher/src/backend/SSHService.js
@@ -119,7 +119,7 @@ export class SSHService {
         privateKey: this.connectionInfo.privateKey || undefined
       }
       const tunnelOptions = {
-        autoClose: true
+        autoClose: false
       };
       const serverOptions = {
         port: tunnelConfig.localPort,

--- a/launcher/src/background.js
+++ b/launcher/src/background.js
@@ -423,6 +423,10 @@ async function createWindow() {
     win.loadURL("app://./index.html");
   }
 
+  win.on('ready-to-show', async () => {
+    await nodeConnection.closeTunnels()
+});
+
   win.on("close", (e) => {
     if (app.showExitPrompt) {
       e.preventDefault(); // Prevents the window from closing


### PR DESCRIPTION
## Tunnel Issue
reloading the app in dev mode, caused the app to throw an error due to `tunnel-ssh` configured with `autoClose: true` some tunnels where closed some not and at the same time the app was already looking for new free ports to open which then caused this issue