### PR TITLE
FIX: Nimbus MevBoost Dependencies

### DIFF
--- a/launcher/src/backend/ServiceManager.js
+++ b/launcher/src/backend/ServiceManager.js
@@ -428,7 +428,8 @@ export class ServiceManager {
         builderCommand = "--builder.urls=";
         break;
       case "NimbusBeaconService":
-        command.push("--payload-builder=true");
+        if (!command.includes("--payload-builder=true"))
+          command.push("--payload-builder=true");
         builderCommand = "--payload-builder-url=";
         break;
       case "TekuBeaconService":


### PR DESCRIPTION
When changing the mev config `--payload-builder=true` was always added to nimbus