### PR TITLE
FIX: dashboard and object availability

### DIFF
--- a/launcher/src/backend/Monitoring.js
+++ b/launcher/src/backend/Monitoring.js
@@ -1688,6 +1688,9 @@ export class Monitoring {
         .filter((p) => p.servicePort == services[execution.service])
         .slice(-1)
         .pop();
+      if (typeof rpc !== "object" || !rpc.hasOwnProperty("destinationIp") || !rpc.hasOwnProperty("destinationPort")) {
+        continue;
+      }
       rpc.destinationIp = rpc.destinationIp == "0.0.0.0" ? "127.0.0.1" : rpc.destinationIp; // FIX: rpc.destinationIp could be 0.0.0.0 if config was changed in expert mode
       let addr = rpc.destinationIp;
       let port = rpc.destinationPort;
@@ -1868,6 +1871,9 @@ export class Monitoring {
         .filter((p) => p.servicePort == services[execution.service])
         .slice(-1)
         .pop();
+      if (typeof ws !== "object" || !ws.hasOwnProperty("destinationIp") || !ws.hasOwnProperty("destinationPort")) {
+        continue;
+      }
       ws.destinationIp = ws.destinationIp == "0.0.0.0" ? "127.0.0.1" : ws.destinationIp; // FIX: ws.destinationIp could be 0.0.0.0 if config was changed in expert mode
       let addr = ws.destinationIp;
       let port = ws.destinationPort;

--- a/launcher/src/components/UI/the-control/PeerToPeer.vue
+++ b/launcher/src/components/UI/the-control/PeerToPeer.vue
@@ -139,16 +139,25 @@ export default {
       }
       let gid = pageNumber - 1;
       let clients =
-        this.p2pstatus.hasOwnProperty("data") && Array.isArray(this.p2pstatus.data) && gid in this.p2pstatus.data
+        this.p2pstatus &&
+        this.p2pstatus.hasOwnProperty("data") &&
+        Array.isArray(this.p2pstatus.data) &&
+        gid in this.p2pstatus.data
           ? this.p2pstatus.data[gid]
           : false;
       if (!clients) {
         let clients_first =
-          this.p2pstatus.hasOwnProperty("data") && Array.isArray(this.p2pstatus.data) && this.p2pstatus.data.length > 0
+          this.p2pstatus &&
+          this.p2pstatus.hasOwnProperty("data") &&
+          Array.isArray(this.p2pstatus.data) &&
+          this.p2pstatus.data.length > 0
             ? this.p2pstatus.data[0]
             : false;
         let clients_last =
-          this.p2pstatus.hasOwnProperty("data") && Array.isArray(this.p2pstatus.data) && this.p2pstatus.data.length > 0
+          this.p2pstatus &&
+          this.p2pstatus.hasOwnProperty("data") &&
+          Array.isArray(this.p2pstatus.data) &&
+          this.p2pstatus.data.length > 0
             ? this.p2pstatus.data[this.p2pstatus.data.length - 1]
             : false;
         if (pageNumber < 1 && clients_last !== false) {
@@ -163,7 +172,7 @@ export default {
           clients = this.p2pstatus.data[gid];
         } else {
           // waiting for data on page load (or while invalid data is retrieved)
-          if (this.p2pstatus.hasOwnProperty("data") && this.p2pstatus.data.hasOwnProperty("error")) {
+          if (this.p2pstatus && this.p2pstatus.hasOwnProperty("data") && this.p2pstatus.data.hasOwnProperty("error")) {
             if (this.p2pstatus.data.error == "prometheus service not running") {
               this.p2pItemsShow = false;
               this.p2pIcoUnknown = true;

--- a/launcher/src/components/UI/the-control/PortList.vue
+++ b/launcher/src/components/UI/the-control/PortList.vue
@@ -8,7 +8,12 @@
         <span>OPEN PORTS</span>
       </div>
       <div class="portlist-data_box">
-        <div v-for="item in portstatus.data" :key="item.id" class="portlist-data_row">
+        <div
+          v-if="portstatus && portstatus.data"
+          v-for="item in portstatus.data"
+          :key="item.id"
+          class="portlist-data_row"
+        >
           <div class="rowName">
             <span>{{ item.name }}</span>
           </div>

--- a/launcher/src/components/UI/the-control/SyncStatus.vue
+++ b/launcher/src/components/UI/the-control/SyncStatus.vue
@@ -205,7 +205,7 @@ export default {
     },
     syncItemSytle(item) {
       item = JSON.parse(JSON.stringify(item)); // toRaw()
-      if (!item.hasOwnProperty("style")) {
+      if (item && !item.hasOwnProperty("style")) {
         return "";
       }
       return item.style;
@@ -242,17 +242,22 @@ export default {
       }
       let gid = pageNum - 1;
       let clients =
-        this.syncstatus.hasOwnProperty("data") && Array.isArray(this.syncstatus.data) && gid in this.syncstatus.data
+        this.syncstatus &&
+        this.syncstatus.hasOwnProperty("data") &&
+        Array.isArray(this.syncstatus.data) &&
+        gid in this.syncstatus.data
           ? this.syncstatus.data[gid]
           : false;
       if (!clients) {
         let clients_first =
+          this.syncstatus &&
           this.syncstatus.hasOwnProperty("data") &&
           Array.isArray(this.syncstatus.data) &&
           this.syncstatus.data.length > 0
             ? this.syncstatus.data[0]
             : false;
         let clients_last =
+          this.syncstatus &&
           this.syncstatus.hasOwnProperty("data") &&
           Array.isArray(this.syncstatus.data) &&
           this.syncstatus.data.length > 0
@@ -270,7 +275,11 @@ export default {
           clients = this.syncstatus.data[gid];
         } else {
           // waiting for data on page load (or while invalid data is retrieved)
-          if (this.syncstatus.hasOwnProperty("data") && this.syncstatus.data.hasOwnProperty("error")) {
+          if (
+            this.syncstatus &&
+            this.syncstatus.hasOwnProperty("data") &&
+            this.syncstatus.data.hasOwnProperty("error")
+          ) {
             if (this.syncstatus.data.error == "prometheus service not running") {
               this.syncItemsShow = false;
               this.syncIcoUnknown = true;


### PR DESCRIPTION
These are a few general fixes to:
- avoid an application crash if an object is not available and
- keep the dashboard available after #1203 was added, respectively aslong #1145 is open (see Ansible requirements)

### Summary
- Checks object availability in SyncStatus view
- Checks object availability in P2PStatus view
- Checks object availability in PortList view
- Checks "rpc" and "ws" object availability in (monitoring) backend

