### PR TITLE
ADD: overwrite ignore for grafana

### DIFF
--- a/controls/roles/manage-service/tasks/main.yml
+++ b/controls/roles/manage-service/tasks/main.yml
@@ -4,171 +4,173 @@
 
 - name: Change state of service
   block:
-  - name: Build service configuration's path
-    set_fact:
-      stereum_service_config_path: "/etc/stereum/services/{{ stereum.manage_service.configuration.id }}.yaml"
+    - name: Build service configuration's path
+      set_fact:
+        stereum_service_config_path: "/etc/stereum/services/{{ stereum.manage_service.configuration.id }}.yaml"
 
-  - name: Read service's configuration
-    slurp:
-      src: "{{ stereum_service_config_path }}"
-    register: stereum_service_configuration_raw
-    become: yes
+    - name: Read service's configuration
+      slurp:
+        src: "{{ stereum_service_config_path }}"
+      register: stereum_service_configuration_raw
+      become: yes
 
-  - name: Read variable
-    set_fact:
-      stereum_service_configuration: "{{ stereum_service_configuration_raw.content | b64decode | from_yaml }}"
-    become: yes
+    - name: Read variable
+      set_fact:
+        stereum_service_configuration: "{{ stereum_service_configuration_raw.content | b64decode | from_yaml }}"
+      become: yes
 
-  - name: Build service container's name
-    set_fact:
-      stereum_service_container_name: "stereum-{{ stereum_service_configuration.id }}"
+    - name: Build service container's name
+      set_fact:
+        stereum_service_container_name: "stereum-{{ stereum_service_configuration.id }}"
 
-  - name: Stop service
-    docker_container:
-      name: "{{ stereum_service_container_name }}"
-      stop_timeout: 600
-      state: absent
-    become: yes
-    when: stereum.manage_service.state == "stopped" or stereum.manage_service.state == "restarted"
+    - name: Stop service
+      docker_container:
+        name: "{{ stereum_service_container_name }}"
+        stop_timeout: 600
+        state: absent
+      become: yes
+      when: stereum.manage_service.state == "stopped" or stereum.manage_service.state == "restarted"
 
-  - name: Set directory permissions
-    file:
-      path: "{{ item.split(':') | first }}"
-      state: directory
-      owner: "{{ stereum_service_configuration.user }}"
-      group: "{{ stereum_service_configuration.user }}"
-      mode: 0700
-      recurse: yes
-    changed_when: false
-    become: yes
-    when: (stereum.manage_service.state == "started" or stereum.manage_service.state == "restarted") and item.split(':') | first != '/'
-    with_items: "{{ stereum_service_configuration.volumes | reject('search', ':/engine.jwt') }}"
+    - name: Set directory permissions
+      file:
+        path: "{{ item.split(':') | first }}"
+        state: directory
+        owner: "{{ stereum_service_configuration.user }}"
+        group: "{{ stereum_service_configuration.user }}"
+        mode: 0700
+        recurse: yes
+      changed_when: false
+      become: yes
+      when: (stereum.manage_service.state == "started" or stereum.manage_service.state == "restarted") and item.split(':') | first != '/'
+      with_items: "{{ stereum_service_configuration.volumes | reject('search', ':/engine.jwt') }}"
 
-  - name: Set directory permissions for engine.jwt
-    file:
-      path: "{{ item.split(':') | first | replace('/engine.jwt', '') }}"
-      state: directory
-      owner: "{{ stereum_service_configuration.user }}"
-      group: "{{ stereum_service_configuration.user }}"
-      mode: 0777
-      recurse: no
-    changed_when: false
-    become: yes
-    when: stereum.manage_service.state == "started" or stereum.manage_service.state == "restarted"
-    with_items: "{{ stereum_service_configuration.volumes | select('search', ':/engine.jwt') }}"
+    - name: Set directory permissions for engine.jwt
+      file:
+        path: "{{ item.split(':') | first | replace('/engine.jwt', '') }}"
+        state: directory
+        owner: "{{ stereum_service_configuration.user }}"
+        group: "{{ stereum_service_configuration.user }}"
+        mode: 0777
+        recurse: no
+      changed_when: false
+      become: yes
+      when: stereum.manage_service.state == "started" or stereum.manage_service.state == "restarted"
+      with_items: "{{ stereum_service_configuration.volumes | select('search', ':/engine.jwt') }}"
 
-  - name: Stereum's docker network
-    docker_network:
-      name: stereum
+    - name: Stereum's docker network
+      docker_network:
+        name: stereum
 
-  - name: Set firewall rules
-    ufw:
-      direction: in
-      dest: "{{ 'any' if (item.split(':') | first) == '0.0.0.0' else (item.split(':') | first) }}"
-      rule: allow
-      port: "{{ item.split(':')[1] }}"
-      proto: "{{ item.split('/')[1] | default('any') }}"
-      delete: "{{ 'yes' if stereum.manage_service.state == 'stopped' else 'no' }}"
-    environment:
-      PATH: /sbin:{{ ansible_env.PATH }}
-    with_items: "{{ stereum_service_configuration.ports }}"
-    when: stereum.manage_service.state != "restarted" and stereum_service_configuration.ports is defined
+    - name: Set firewall rules
+      ufw:
+        direction: in
+        dest: "{{ 'any' if (item.split(':') | first) == '0.0.0.0' else (item.split(':') | first) }}"
+        rule: allow
+        port: "{{ item.split(':')[1] }}"
+        proto: "{{ item.split('/')[1] | default('any') }}"
+        delete: "{{ 'yes' if stereum.manage_service.state == 'stopped' else 'no' }}"
+      environment:
+        PATH: /sbin:{{ ansible_env.PATH }}
+      with_items: "{{ stereum_service_configuration.ports }}"
+      when: stereum.manage_service.state != "restarted" and stereum_service_configuration.ports is defined
 
-  - name: Copy ssz files
-    copy:
-      src: "{{ role_path }}/files/prysm-prater-genesis.ssz"
-      dest: "{{ item.split(':') | first }}/prysm-prater-genesis.ssz"
-      mode: 0644
-    become: yes
-    when: >
-      (stereum_service_configuration.image is match("prysmaticlabs/prysm-beacon-chain:*") or
-      stereum_service_configuration.image is match("gcr.io/prysmaticlabs/prysm/beacon-chain:*")) and
-      stereum_service_configuration.command.find("prater") != -1 and
-      "genesis" in item
-    with_items: "{{ stereum_service_configuration.volumes }}"
+    - name: Copy ssz files
+      copy:
+        src: "{{ role_path }}/files/prysm-prater-genesis.ssz"
+        dest: "{{ item.split(':') | first }}/prysm-prater-genesis.ssz"
+        mode: 0644
+      become: yes
+      when: >
+        (stereum_service_configuration.image is match("prysmaticlabs/prysm-beacon-chain:*") or
+        stereum_service_configuration.image is match("gcr.io/prysmaticlabs/prysm/beacon-chain:*")) and
+        stereum_service_configuration.command.find("prater") != -1 and
+        "genesis" in item
+      with_items: "{{ stereum_service_configuration.volumes }}"
 
-  - name: Generate JWT (execution client only)
-    copy:
-      # besu prevents the use of tokens starting with '0x', so we start always with 'ff'
-      content: "ff{{ query('community.general.random_string', override_all=hex_chars, length=62) | first }}"
-      dest: "{{ stereum_service_configuration.volumes | select('search', ':/engine.jwt') | first | split(':') | first }}"
-      force: no
-      mode: 0444
-    vars:
-        hex_chars: '0123456789abcdef'
-    become: yes
-    when:
-      - stereum_service_configuration.service in ['BesuService', 'GethService', 'NethermindService', 'ErigonService', 'LighthouseBeaconService', 'NimbusBeaconService', 'PrysmBeaconService', 'TekuBeaconService', 'LodestarBeaconService']
-      - stereum_service_configuration.volumes | select('search', ':/engine.jwt') | length > 0
+    - name: Generate JWT (execution client only)
+      copy:
+        # besu prevents the use of tokens starting with '0x', so we start always with 'ff'
+        content: "ff{{ query('community.general.random_string', override_all=hex_chars, length=62) | first }}"
+        dest: "{{ stereum_service_configuration.volumes | select('search', ':/engine.jwt') | first | split(':') | first }}"
+        force: no
+        mode: 0444
+      vars:
+        hex_chars: "0123456789abcdef"
+      become: yes
+      when:
+        - stereum_service_configuration.service in ['BesuService', 'GethService', 'NethermindService', 'ErigonService', 'LighthouseBeaconService', 'NimbusBeaconService', 'PrysmBeaconService', 'TekuBeaconService', 'LodestarBeaconService']
+        - stereum_service_configuration.volumes | select('search', ':/engine.jwt') | length > 0
 
-  - include_tasks: write-graffiti-files.yml
-    when: >
-      stereum_service_configuration.volumes | select('search', '/graffitis') | length > 0 and
-      (stereum.manage_service.state == "started" or stereum.manage_service.state == "restarted")
+    - include_tasks: write-graffiti-files.yml
+      when: >
+        stereum_service_configuration.volumes | select('search', '/graffitis') | length > 0 and
+        (stereum.manage_service.state == "started" or stereum.manage_service.state == "restarted")
 
-  - include_tasks: write-grafana-configuration.yml
-    when: >
-      stereum_service_configuration.image is match("grafana/grafana:*") and
-      (stereum.manage_service.state == "started" or stereum.manage_service.state == "restarted")
+    - include_tasks: write-grafana-configuration.yml
+      when: >
+        stereum_service_configuration.image is match("grafana/grafana:*") and
+        (stereum.manage_service.state == "started" or stereum.manage_service.state == "restarted") and
+        stereum_service_configuration.overwrite | default(true)
 
-  - include_tasks: write-prometheus-configuration.yml
-    when: >
-      stereum_service_configuration.image is match("prom/prometheus:*") and
-      (stereum.manage_service.state == "started" or stereum.manage_service.state == "restarted") and
-      stereum_service_configuration.overwrite | default(true)
+    - include_tasks: write-prometheus-configuration.yml
+      when: >
+        stereum_service_configuration.image is match("prom/prometheus:*") and
+        (stereum.manage_service.state == "started" or stereum.manage_service.state == "restarted") and
+        stereum_service_configuration.overwrite | default(true)
 
-  - include_tasks: nimbus-checkpoint-sync.yml
-    when: >
-      stereum_service_configuration.command is defined and
-      (stereum_service_configuration.command | select('match', "^--trusted-node-url=") | length) == 1 and
-      stereum_service_configuration.service is match("NimbusBeaconService") and
-      (stereum.manage_service.state == "started" or stereum.manage_service.state == "restarted")
+    - include_tasks: nimbus-checkpoint-sync.yml
+      when: >
+        stereum_service_configuration.command is defined and
+        (stereum_service_configuration.command | select('match', "^--trusted-node-url=") | length) == 1 and
+        stereum_service_configuration.service is match("NimbusBeaconService") and
+        (stereum.manage_service.state == "started" or stereum.manage_service.state == "restarted")
 
-  - name: Start service
-    community.docker.docker_container:
-      command_handling: correct
-      hostname: "{{ stereum_service_container_name }}"
-      name: "{{ stereum_service_container_name }}"
-      user: "{{ stereum_service_configuration.user }}"
-      image: "{{ stereum_service_configuration.image }}"
-      env: "{{ stereum_service_configuration.env | default({}) }}"
-      command: "{{ stereum_service_configuration.command | default([]) }}"
-      entrypoint: "{{ stereum_service_configuration.entrypoint | default([]) }}"
-      restart_policy: "unless-stopped"
-      state: started
-      # recreate: yes # default: no
-      ports: "{{ stereum_service_configuration.ports | default([]) }}"
-      networks:
-        - name: stereum
-          aliases: "{{ ['prometheus'] if (stereum_service_configuration.image is match('prom/prometheus:*')) else (['notifications'] if (stereum_service_configuration.image is match('stereum/notifications:*')) else []) }}"
-      # working_dir: "{{ stereum_service_configuration.working_dir }}" # doesn't work at all
-      volumes: "{{ stereum_service_configuration.volumes }}"
-      log_driver: "json-file"
-      log_options:
-        max-file: "10"
-        max-size: "100m"
-    become: yes
-    when: stereum.manage_service.state == "started" or stereum.manage_service.state == "restarted"
+    - name: Start service
+      community.docker.docker_container:
+        command_handling: correct
+        hostname: "{{ stereum_service_container_name }}"
+        name: "{{ stereum_service_container_name }}"
+        user: "{{ stereum_service_configuration.user }}"
+        image: "{{ stereum_service_configuration.image }}"
+        env: "{{ stereum_service_configuration.env | default({}) }}"
+        command: "{{ stereum_service_configuration.command | default([]) }}"
+        entrypoint: "{{ stereum_service_configuration.entrypoint | default([]) }}"
+        restart_policy: "unless-stopped"
+        state: started
+        # recreate: yes # default: no
+        ports: "{{ stereum_service_configuration.ports | default([]) }}"
+        networks:
+          - name: stereum
+            aliases: "{{ ['prometheus'] if (stereum_service_configuration.image is match('prom/prometheus:*')) else (['notifications'] if (stereum_service_configuration.image is match('stereum/notifications:*')) else []) }}"
+        # working_dir: "{{ stereum_service_configuration.working_dir }}" # doesn't work at all
+        volumes: "{{ stereum_service_configuration.volumes }}"
+        log_driver: "json-file"
+        log_options:
+          max-file: "10"
+          max-size: "100m"
+      become: yes
+      when: stereum.manage_service.state == "started" or stereum.manage_service.state == "restarted"
 
-  - name: Reload config (prometheus only)
-    community.docker.docker_container:
-      command_handling: correct
-      name: "reload-prometheus"
-      user: "2000"
-      image: "curlimages/curl:{{ stereum_static.defaults.versions.curl }}"
-      detach: false
-      command: |
-        curl -X POST http://prometheus:9090/-/reload -s
-      networks:
-        - name: stereum
-    become: yes
-    when: >
-      stereum_service_configuration.image is match("prom/prometheus:*") and
-      (stereum.manage_service.state == "started" or stereum.manage_service.state == "restarted")
+    - name: Reload config (prometheus only)
+      community.docker.docker_container:
+        command_handling: correct
+        name: "reload-prometheus"
+        user: "2000"
+        image: "curlimages/curl:{{ stereum_static.defaults.versions.curl }}"
+        detach: false
+        command: |
+          curl -X POST http://prometheus:9090/-/reload -s
+        networks:
+          - name: stereum
+      become: yes
+      when: >
+        stereum_service_configuration.image is match("prom/prometheus:*") and
+        (stereum.manage_service.state == "started" or stereum.manage_service.state == "restarted")
 
-  - include_tasks: configure-grafana.yml
-    when: >
-      stereum_service_configuration.image is match("grafana/grafana:*") and
-      (stereum.manage_service.state == "started" or stereum.manage_service.state == "restarted")
+    - include_tasks: configure-grafana.yml
+      when: >
+        stereum_service_configuration.image is match("grafana/grafana:*") and
+        (stereum.manage_service.state == "started" or stereum.manage_service.state == "restarted") and
+        stereum_service_configuration.overwrite | default(true)
 
   when: stereum.manage_service.state is defined

--- a/launcher/src/pages/TheNode.vue
+++ b/launcher/src/pages/TheNode.vue
@@ -54,7 +54,7 @@
         <div class="service">
           <div class="title">{{ $t("theNode.servicePlugin") }}</div>
           <div class="service-parent">
-            <node-service :list="installedServices.filter((service) => service.category === 'service')"> </node-service>
+            <node-service :list="installedServices.filter((service) => service.category === 'service').sort(sortByName)"> </node-service>
           </div>
         </div>
         <div class="node-side">


### PR DESCRIPTION
Add `overwrite: false` to your grafana config via `Expert Mode` to keep your custom dashboards, contact points etc...

Changed the sorting for the Services on the right for the `Node Manage` Page, so if you change your view the icons stay the same position.