### PR TITLE
FIX: show sync status also for EC not reporting stats properly

### DIFF
--- a/launcher/src/backend/Monitoring.js
+++ b/launcher/src/backend/Monitoring.js
@@ -1015,7 +1015,7 @@ export class Monitoring {
 
     // Execution clients that should be queried by RPC for chain head block
     const get_chain_head_by_rpc = [
-      // 'GethService',
+      "GethService",
       // 'BesuService',
       "NethermindService",
       "ErigonService",

--- a/launcher/src/backend/Monitoring.js
+++ b/launcher/src/backend/Monitoring.js
@@ -18,8 +18,8 @@ const globalMonitoringCache = {
 
 export class Monitoring {
   constructor(nodeConnection) {
-    this.nodeConnection = nodeConnection
-    this.nodeConnectionProm = nodeConnection
+    this.nodeConnection = nodeConnection;
+    this.nodeConnectionProm = nodeConnection;
     this.serviceManager = new ServiceManager(this.nodeConnection);
     this.serviceManagerProm = new ServiceManager(this.nodeConnectionProm);
     this.isLoggedIn = false;
@@ -40,7 +40,7 @@ export class Monitoring {
     this.globalMonitoringCache = { ...globalMonitoringCache };
     try {
       fs.unlinkSync(this.serviceInfosCacheFile);
-    } catch (e) { }
+    } catch (e) {}
   }
 
   // Jobs to handle on login
@@ -228,7 +228,7 @@ export class Monitoring {
         }
         //console.log('REQUIRE fresh cache ' + hash, dnow);
       }
-    } catch (e) { }
+    } catch (e) {}
     if (await this.checkStereumInstallation()) {
       var serviceConfigs = await this.serviceManagerProm.readServiceConfigurations();
       const serviceStates = await this.nodeConnectionProm.listServices();
@@ -387,11 +387,11 @@ export class Monitoring {
     var query =
       rpc_method.trim().indexOf("{") < 0
         ? JSON.stringify({
-          jsonrpc: "2.0",
-          method: rpc_method.trim(),
-          params: rpc_params,
-          id: 1,
-        })
+            jsonrpc: "2.0",
+            method: rpc_method.trim(),
+            params: rpc_params,
+            id: 1,
+          })
         : rpc_method;
 
     // Define default response
@@ -1017,7 +1017,7 @@ export class Monitoring {
     const get_chain_head_by_rpc = [
       // 'GethService',
       // 'BesuService',
-      // 'NethermindService',
+      "NethermindService",
       "ErigonService",
     ];
 
@@ -1122,12 +1122,12 @@ export class Monitoring {
             labels.forEach(function (label, index) {
               try {
                 results[label] = xx.filter((s) => s.metric.__name__ == labels[index])[0].value[1];
-              } catch (e) { }
+              } catch (e) {}
             });
             try {
               frstVal = results[labels[1]];
               scndVal = results[labels[0]];
-            } catch (e) { }
+            } catch (e) {}
           }
           // Set chain head block for this client from RPC server (if available)
           if (
@@ -1144,7 +1144,7 @@ export class Monitoring {
                 typeof chain_head_block === "string" && chain_head_block.startsWith("0x")
                   ? parseInt(chain_head_block, 16)
                   : 0;
-            } catch (e) { }
+            } catch (e) {}
             let stay_on_hold_till_first_block = false; // true = enabled | false = disabled
             if (stay_on_hold_till_first_block && !chain_head_block) {
               // stay on hold until EC has responded the first block by RPC
@@ -1447,7 +1447,7 @@ export class Monitoring {
                     .value.pop()
                 );
                 details[clientType]["numPeerBy"]["fields"].push(item);
-              } catch (e) { }
+              } catch (e) {}
             });
           }
 
@@ -1704,7 +1704,7 @@ export class Monitoring {
         await this.nodeConnection.closeTunnels(openTunnels);
         this.rpcTunnel = {};
       }
-    } catch (e) { }
+    } catch (e) {}
 
     // Respond success with fresh RPC status data
     const freshrpcstatus = await this.getRpcStatus();
@@ -1887,7 +1887,7 @@ export class Monitoring {
         await this.nodeConnection.closeTunnels(openTunnels);
         this.wsTunnel = {};
       }
-    } catch (e) { }
+    } catch (e) {}
 
     // Respond success with fresh WS status data
     const freshwsstatus = await this.getWsStatus();
@@ -2037,7 +2037,7 @@ export class Monitoring {
     try {
       let r = wsResult.stdout.trim().split("\n");
       statuscode = r.length > 0 ? parseInt(r.pop()) : statuscode;
-    } catch (e) { }
+    } catch (e) {}
 
     // Respond true if websocket is available, false otherwise
     if (!wsResult.stdout.toLowerCase().includes("sec-websocket") && statuscode != 200) {
@@ -2144,7 +2144,7 @@ export class Monitoring {
         await this.nodeConnection.closeTunnels(openTunnels);
         this.beaconTunnel = {};
       }
-    } catch (e) { }
+    } catch (e) {}
 
     // Respond success with fresh BEACON status data
     const freshbeaconstatus = await this.getBeaconStatus();
@@ -2269,8 +2269,8 @@ export class Monitoring {
     const addr_type = Array.isArray(addr)
       ? "arr"
       : typeof addr === "string" && ["public", "local"].includes(addr)
-        ? "str"
-        : "invalid";
+      ? "str"
+      : "invalid";
     addr = addr_type == "str" ? addr.toLowerCase().trim() : addr;
     if (addr_type == "invalid") {
       return {
@@ -2358,7 +2358,7 @@ export class Monitoring {
     for (let i = 0; i < serviceInfos.length; i++) {
       const hashDependencies =
         serviceInfos[i].config.dependencies.consensusClients.length ||
-          serviceInfos[i].config.dependencies.executionClients.length
+        serviceInfos[i].config.dependencies.executionClients.length
           ? "yes"
           : "no";
       easyInfos.push({


### PR DESCRIPTION
Besu is the only EC that currently does report sync stats properly to Prometheus.
This workaround requests the sync status for all other EC by BEACON/RPC API and fixes #1274.