### PR TITLE
ADD: format check, lockfile delete button

### DIFF
--- a/launcher/src/backend/ServiceManager.js
+++ b/launcher/src/backend/ServiceManager.js
@@ -200,6 +200,9 @@ export class ServiceManager {
         await this.resyncService(service, data);
         break;
 
+      case "removeLockfiles":
+        await this.removeTekuLockFiles(service.config.serviceID)
+        break;
       default:
         break;
     }
@@ -1435,5 +1438,15 @@ export class ServiceManager {
       );
     }
     return runRefs;
+  }
+
+  async removeTekuLockFiles(serviceID) {
+    let services = await this.readServiceConfigurations();
+    let service = services.find((s) => s.id === serviceID);
+    let workingDir = this.getWorkindDir(service);
+    if (!workingDir.endsWith("/")) {
+      workingDir += "/";
+    }
+    await this.nodeConnection.sshService.exec(`rm ${workingDir}/data/validator/key-manager/local/*.lock`)
   }
 }

--- a/launcher/src/components/UI/the-node/TheExpert.vue
+++ b/launcher/src/components/UI/the-node/TheExpert.vue
@@ -143,7 +143,9 @@
         -->
 
         <div
-          v-for="(option, index) in item.expertOptions.filter((option) => option.type === 'action')"
+          v-for="(option, index) in item.expertOptions.filter(
+            (option) => option.type === 'action' && option.action === 'pruning'
+          )"
           :key="index"
           class="actionBox"
           :class="{ unvisible: isExpertModeActive }"
@@ -162,6 +164,18 @@
               <span class="slider round"></span>
             </label>
           </div>
+        </div>
+        <div
+          v-for="(option, index) in item.expertOptions.filter(
+            (option) => option.type === 'action' && option.action === 'removeLockfiles'
+          )"
+          :key="index"
+          class="actionBox"
+          :class="{ unvisible: isExpertModeActive }"
+        >
+          <img :src="option.icon" alt="icon" />
+          <span class="actionBoxTitle">{{ option.title }}</span>
+          <span class="actionBtn" @click="executeAction(option.action, item)">Execute</span>
         </div>
         <div
           v-for="(option, index) in item.expertOptions.filter((option) => option.type === 'toggle')"
@@ -462,6 +476,9 @@ export default {
       this.confirmExpertChanges(el);
       await ControlService.restartService(el.config.serviceID);
     },
+    async executeAction(action, service) {
+      await ControlService.chooseServiceAction({ action: action, service: structuredClone(service) });
+    },
   },
 };
 </script>
@@ -617,6 +634,26 @@ export default {
   background-color: #1a2e2a;
 }
 .expertRow .docBox .openBtn:active {
+  transform: scale(0.95);
+}
+.actionBtn {
+  grid-row: 1/2;
+  /* width: 100%;
+  height: 100%; */
+  padding-top: 2px;
+  background-color: #264744;
+  border-radius: 35px;
+  text-align: center;
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: #dbdbdb;
+  cursor: pointer;
+}
+.actionBtn:hover {
+  background-color: #1a2e2a;
+}
+.actionBtn:active {
   transform: scale(0.95);
 }
 .expertRow .selectBox {

--- a/launcher/src/store/services.js
+++ b/launcher/src/store/services.js
@@ -317,7 +317,7 @@ export const useServices = defineStore("services", {
             {
               title: "RAM Usage Limit",
               type: "select",
-              value: [2, 4, 8, 16],
+              value: [2, 4, 6, 8, 10, 12, 14, 16, 20, 24, 28, 32, 48, 64],
               changeValue: null,
               icon: "/img/icon/plugin-menu-icons/ram.png",
               unit: "GB",
@@ -367,7 +367,7 @@ export const useServices = defineStore("services", {
             {
               title: "RAM Usage Limit",
               type: "select",
-              value: [2, 4, 8, 16],
+              value: [2, 4, 6, 8, 10, 12, 14, 16, 20, 24, 28, 32, 48, 64],
               changeValue: null,
               icon: "/img/icon/plugin-menu-icons/ram.png",
               unit: "GB",
@@ -386,6 +386,14 @@ export const useServices = defineStore("services", {
               changeValue: true,
               icon: "/img/icon/plugin-menu-icons/doppelganger.png",
               pattern: "(- --doppelganger-detection-enabled=)(.*)(\\n)",
+            },
+            {
+              title: "Remove Lockfiles",
+              type: "action",
+              action: "removeLockfiles",
+              changeValue: null,
+              displayWarningModal: false,
+              icon: "/img/icon/plugin-menu-icons/prunning.png",
             },
           ],
           drag: true,


### PR DESCRIPTION
## Option to remove Teku Lockfiles
The Teku Valdiator Export Mode now includes a button which removes validator lockfiles. this should make it easier for users to resolve their teku issues after teku crashes. fixes #1050

## Check for wrong service formats
Changes to service configs via Expert Mode are now checked for the correct format before writing.
Tht `write yaml` task will fail if the format is not correct. fixes #1272