### PR TITLE
Update Nethermind executable name

### DIFF
--- a/controls/roles/manage-service/molecule/mevboost-nethermind-lighthouse/converge.yml
+++ b/controls/roles/manage-service/molecule/mevboost-nethermind-lighthouse/converge.yml
@@ -29,7 +29,7 @@
               ports:
                 - 0.0.0.0:30303:30303/tcp
                 - 0.0.0.0:30303:30303/udp
-              entrypoint: ["./Nethermind.Runner"]
+              entrypoint: ["./nethermind"]
               env: {}
               command:
               - --config=goerli

--- a/controls/roles/manage-service/molecule/mevboost-nethermind-nimbus/converge.yml
+++ b/controls/roles/manage-service/molecule/mevboost-nethermind-nimbus/converge.yml
@@ -28,7 +28,7 @@
               ports:
                 - 0.0.0.0:30303:30303/tcp
                 - 0.0.0.0:30303:30303/udp
-              entrypoint: ["./Nethermind.Runner"]
+              entrypoint: ["./nethermind"]
               env: {}
               command:
               - --config=goerli

--- a/controls/roles/manage-service/molecule/mevboost-nethermind-prysm/converge.yml
+++ b/controls/roles/manage-service/molecule/mevboost-nethermind-prysm/converge.yml
@@ -29,7 +29,7 @@
               ports:
                 - 0.0.0.0:30303:30303/tcp
                 - 0.0.0.0:30303:30303/udp
-              entrypoint: ["./Nethermind.Runner"]
+              entrypoint: ["./nethermind"]
               env: {}
               command:
               - --config=goerli

--- a/controls/roles/manage-service/molecule/mevboost-nethermind-teku/converge.yml
+++ b/controls/roles/manage-service/molecule/mevboost-nethermind-teku/converge.yml
@@ -28,7 +28,7 @@
               ports:
                 - 0.0.0.0:30303:30303/tcp
                 - 0.0.0.0:30303:30303/udp
-              entrypoint: ["./Nethermind.Runner"]
+              entrypoint: ["./nethermind"]
               env: {}
               command:
               - --config=goerli

--- a/controls/roles/manage-service/molecule/monitor-nethermind/prepare.yml
+++ b/controls/roles/manage-service/molecule/monitor-nethermind/prepare.yml
@@ -49,7 +49,7 @@
               ports:
                 - 0.0.0.0:30303:30303/tcp
                 - 0.0.0.0:30303:30303/udp
-              entrypoint: ["./Nethermind.Runner"]
+              entrypoint: ["./nethermind"]
               env: {}
               command:
               - --config=goerli

--- a/controls/roles/manage-service/molecule/nethermind-lighthouse/converge.yml
+++ b/controls/roles/manage-service/molecule/nethermind-lighthouse/converge.yml
@@ -27,7 +27,7 @@
               ports:
                 - 0.0.0.0:30303:30303/tcp
                 - 0.0.0.0:30303:30303/udp
-              entrypoint: ["./Nethermind.Runner"]
+              entrypoint: ["./nethermind"]
               env: {}
               command:
               - --config=goerli

--- a/controls/roles/manage-service/molecule/nethermind-nimbus/converge.yml
+++ b/controls/roles/manage-service/molecule/nethermind-nimbus/converge.yml
@@ -27,7 +27,7 @@
               ports:
                 - 0.0.0.0:30303:30303/tcp
                 - 0.0.0.0:30303:30303/udp
-              entrypoint: ["./Nethermind.Runner"]
+              entrypoint: ["./nethermind"]
               env: {}
               command:
               - --config=goerli

--- a/controls/roles/manage-service/molecule/nethermind-prysm/converge.yml
+++ b/controls/roles/manage-service/molecule/nethermind-prysm/converge.yml
@@ -27,7 +27,7 @@
               ports:
                 - 0.0.0.0:30303:30303/tcp
                 - 0.0.0.0:30303:30303/udp
-              entrypoint: ["./Nethermind.Runner"]
+              entrypoint: ["./nethermind"]
               env: {}
               command:
               - --config=goerli

--- a/controls/roles/manage-service/molecule/nethermind-teku-gnosis/converge.yml
+++ b/controls/roles/manage-service/molecule/nethermind-teku-gnosis/converge.yml
@@ -27,7 +27,7 @@
               ports:
                 - 0.0.0.0:30303:30303/tcp
                 - 0.0.0.0:30303:30303/udp
-              entrypoint: ["./Nethermind.Runner"]
+              entrypoint: ["./nethermind"]
               env: {}
               command:
               - --config=gnosis

--- a/controls/roles/manage-service/molecule/nethermind-teku/converge.yml
+++ b/controls/roles/manage-service/molecule/nethermind-teku/converge.yml
@@ -27,7 +27,7 @@
               ports:
                 - 0.0.0.0:30303:30303/tcp
                 - 0.0.0.0:30303:30303/udp
-              entrypoint: ["./Nethermind.Runner"]
+              entrypoint: ["./nethermind"]
               env: {}
               command:
               - --config=goerli

--- a/controls/roles/update-changes/molecule/20-rc10/prepare.yml
+++ b/controls/roles/update-changes/molecule/20-rc10/prepare.yml
@@ -242,7 +242,7 @@
           ports:
             - 0.0.0.0:30303:30303/tcp
             - 0.0.0.0:30303:30303/udp
-          entrypoint: ["./Nethermind.Runner"]
+          entrypoint: ["./nethermind"]
           env: {}
           command:
             - --config=gnosis

--- a/controls/roles/update-changes/molecule/20-rc12/prepare.yml
+++ b/controls/roles/update-changes/molecule/20-rc12/prepare.yml
@@ -242,7 +242,7 @@
           ports:
             - 0.0.0.0:30303:30303/tcp
             - 0.0.0.0:30303:30303/udp
-          entrypoint: ["./Nethermind.Runner"]
+          entrypoint: ["./nethermind"]
           env: {}
           command:
             - --config=gnosis

--- a/controls/roles/update-changes/molecule/20-rc13/prepare.yml
+++ b/controls/roles/update-changes/molecule/20-rc13/prepare.yml
@@ -242,7 +242,7 @@
           ports:
             - 0.0.0.0:30303:30303/tcp
             - 0.0.0.0:30303:30303/udp
-          entrypoint: ["./Nethermind.Runner"]
+          entrypoint: ["./nethermind"]
           env: {}
           command:
             - --config=gnosis

--- a/controls/roles/update-changes/molecule/20-rc18/prepare.yml
+++ b/controls/roles/update-changes/molecule/20-rc18/prepare.yml
@@ -179,7 +179,7 @@
             - --HealthChecks.Enabled=true
             - --Pruning.Mode=Hybrid
           entrypoint:
-            - ./Nethermind.Runner
+            - ./nethermind
           env: {}
           image: nethermind/nethermind:1.18.0
           ports:

--- a/launcher/src/backend/ethereum-services/NethermindService.js
+++ b/launcher/src/backend/ethereum-services/NethermindService.js
@@ -40,7 +40,7 @@ export class NethermindService extends NodeService {
         "--HealthChecks.Enabled=true",
         "--Pruning.Mode=Hybrid",
       ], // command
-      ["./Nethermind.Runner"], // entrypoint
+      ["./nethermind"], // entrypoint
       null, // env
       ports, // ports
       volumes, // volumes

--- a/launcher/src/backend/ethereum-services/NethermindService.test.js
+++ b/launcher/src/backend/ethereum-services/NethermindService.test.js
@@ -16,7 +16,7 @@ test("buildByUserInput", () => {
   expect(nethermindService.image).toContain("nethermind/nethermind");
   expect(nethermindService.command).toContain("--config=goerli");
   expect(nethermindService.command).toContain("--datadir=/opt/app/data");
-  expect(nethermindService.entrypoint).toContain("./Nethermind.Runner");
+  expect(nethermindService.entrypoint).toContain("./nethermind");
   expect(nethermindService.ports).toHaveLength(1);
   expect(nethermindService.ports).toContain("0.0.0.0:4040:4040/tcp");
   expect(nethermindService.volumes).toContain(


### PR DESCRIPTION
We renamed the Nethermind executable from `Nethermind.Runner` to `nethermind`. This PR updates all references to those.

To be merged once the next version of Nethermind is released.