### PR TITLE
REMOVE: Bloxroute ethical relay

### DIFF
--- a/launcher/src/backend/NodeConnection.js
+++ b/launcher/src/backend/NodeConnection.js
@@ -330,17 +330,17 @@ export class NodeConnection {
         "             ANSIBLE_LOAD_CALLBACK_PLUGINS=1\
                         ANSIBLE_STDOUT_CALLBACK=stereumjson\
                         ANSIBLE_LOG_FOLDER=/tmp/" +
-          playbookRunRef +
-          "\
+        playbookRunRef +
+        "\
                         ansible-playbook\
                         --connection=local\
                         --inventory 127.0.0.1,\
                         --extra-vars " +
-          StringUtils.escapeStringForShell(extraVarsJson) +
-          "\
+        StringUtils.escapeStringForShell(extraVarsJson) +
+        "\
                         " +
-          this.settings.stereum.settings.controls_install_path +
-          "/ansible/controls/genericPlaybook.yaml\
+        this.settings.stereum.settings.controls_install_path +
+        "/ansible/controls/genericPlaybook.yaml\
                         "
       );
     } catch (err) {
@@ -587,10 +587,10 @@ export class NodeConnection {
       }
       configStatus = await this.sshService.exec(
         "echo -e " +
-          StringUtils.escapeStringForShell(service.data.trim()) +
-          " > /etc/stereum/services/" +
-          service.id +
-          ".yaml"
+        StringUtils.escapeStringForShell(service.data.trim()) +
+        " > /etc/stereum/services/" +
+        service.id +
+        ".yaml"
       );
     } catch (err) {
       this.taskManager.otherSubTasks.push({
@@ -636,10 +636,10 @@ export class NodeConnection {
     try {
       configStatus = await this.sshService.exec(
         "echo -e " +
-          StringUtils.escapeStringForShell(YAML.stringify(serviceConfiguration)) +
-          " > /etc/stereum/services/" +
-          serviceConfiguration.id +
-          ".yaml"
+        StringUtils.escapeStringForShell(YAML.stringify(serviceConfiguration)) +
+        " > /etc/stereum/services/" +
+        serviceConfiguration.id +
+        ".yaml"
       );
     } catch (err) {
       this.taskManager.otherSubTasks.push({
@@ -661,9 +661,9 @@ export class NodeConnection {
       this.taskManager.finishedOtherTasks.push({ otherRunRef: ref });
       throw new Error(
         "Failed writing service configuration " +
-          serviceConfiguration.id +
-          ": " +
-          SSHService.extractExecError(configStatus)
+        serviceConfiguration.id +
+        ": " +
+        SSHService.extractExecError(configStatus)
       );
     }
     this.taskManager.otherSubTasks.push({
@@ -1105,11 +1105,11 @@ export class NodeConnection {
     if (status.rc == 0) {
       const ref = StringUtils.createRandomString();
       this.taskManager.otherTasksHandler(ref, "Restarting Server");
-      await new Promise((resolve) => setTimeout(resolve, 10000));
+      await new Promise((resolve) => setTimeout(resolve, 10000)); // Wait for the TaskManager to pick up the task
       await this.sshService.exec("/sbin/shutdown -r now");
       this.taskManager.otherTasksHandler(ref, "trigger restart", true);
       await this.sshService.disconnect();
-
+      await new Promise((resolve) => setTimeout(resolve, 10000)); // Wait for the disconnect to be fully done
       const retry = { connected: false, counter: 0, maxTries: 300 };
       log.info("Connecting via SSH");
 

--- a/launcher/src/backend/OneClickInstall.js
+++ b/launcher/src/backend/OneClickInstall.js
@@ -29,7 +29,7 @@ export class OneClickInstall {
       }
     }
     await this.nodeConnection.sshService.exec(`rm -rf /etc/stereum &&\
-    mkdir /etc/stereum &&\
+    mkdir -p /etc/stereum/services &&\
     echo -e ${StringUtils.escapeStringForShell(YAML.stringify(settings))} > /etc/stereum/stereum.yaml`);
     await this.nodeConnection.findStereumSettings();
     return await this.nodeConnection.prepareStereumNode(
@@ -229,7 +229,7 @@ export class OneClickInstall {
       this.extraServices.push(this.serviceManager.getService("NotificationService", args))
     }
 
-    if(selectedPreset == "archive"){
+    if (selectedPreset == "archive") {
       switch (this.executionClient.service) {
         case "GethService":
           this.executionClient.command.push("--syncmode full");

--- a/launcher/src/store/nodeManage.js
+++ b/launcher/src/store/nodeManage.js
@@ -36,16 +36,6 @@ export const useNodeManage = defineStore("nodeManage", {
         },
         {
           icon: "/img/icon/click-installation/bloxRoute-icon.png",
-          name: "BloXroute ETHICAL",
-          mainnet:
-            "https://0xad0a8bb54565c2211cee576363f3a347089d2f07cf72679d16911d740262694cadb62d7fd7483f27afd714ca0f1b9118@bloxroute.ethical.blxrbdn.com",
-          id: 3,
-          isSelected: false,
-          isRemoved: false,
-          freeCensorship: false,
-        },
-        {
-          icon: "/img/icon/click-installation/bloxRoute-icon.png",
           name: "BloXroute REGULATED",
           mainnet:
             "https://0xb0b07cd0abef743db4260b0ed50619cf6ad4d82064cb4fbec9d3ec530f7c5e6793d9f286c4e082c0244ffb9f2658fe88@bloxroute.regulated.blxrbdn.com",


### PR DESCRIPTION
- Bloxroute ethical relay removed
- Restart failed sometimes on setup
- Monitoring loop tried to get service configs and failed due to missing `/etc/stereum/services` directory. On OneClickInstallations Stereum now creates not only `/etc/stereum` but `/etc/stereum/services` as well