### PR TITLE
FIX: restart/resync of services

### DIFF
--- a/launcher/src/components/UI/the-node/JournalNode.vue
+++ b/launcher/src/components/UI/the-node/JournalNode.vue
@@ -461,7 +461,7 @@ export default {
       if (!service.yaml.includes("isPruning: true")) {
         this.isServiceOn = false;
         service.serviceIsPending = true;
-        await ControlService.restartService(service.config.serviceID);
+        await ControlService.restartService({serviceID: service.config.serviceID, state: service.state});
         service.serviceIsPending = false;
         this.updateStates();
       }


### PR DESCRIPTION
Fixed a bug were services which haven't been started once would throw an error on restart or resync