### PR TITLE
FIX: passwordless sudo detection

### DIFF
--- a/launcher/src/backend/NodeConnection.js
+++ b/launcher/src/backend/NodeConnection.js
@@ -75,7 +75,7 @@ export class NodeConnection {
         exit 0
       fi
       # Check if users needs a password for sudo
-      msg=$(sudo -l 2>&1)
+      msg=$(sudo hostname 2>&1)
       if [[ "$msg" == *"sudo: a password is required"* ]]; then
         echo "FAIL: user can not sudo without password!"
         exit 1


### PR DESCRIPTION
- The passwordless sudo check with "sudo -l" fails
- Check with "sudo hostname" works as expected

fixes #1473
credits @very-common 🚀 