### PR TITLE
FIX: distinguish finalized & preJustified epochs on Control tab

### DIFF
--- a/launcher/src/backend/Monitoring.js
+++ b/launcher/src/backend/Monitoring.js
@@ -3063,7 +3063,7 @@ rm -rf diskoutput
         let currentEpoch = Math.floor(currentSlot / epochLength);
         let currentJustifiedEpoch = parseInt(JSON.parse(beaconAPIEpochRunCmd.stdout).data.current_justified.epoch);
         let previousJustifiedEpoch = parseInt(JSON.parse(beaconAPIEpochRunCmd.stdout).data.previous_justified.epoch);
-        let finalizedEpoch = parseInt(JSON.parse(beaconAPIEpochRunCmd.stdout).data.finalized.epoch);
+        let finalizedEpoch = parseInt(JSON.parse(beaconAPIEpochRunCmd.stdout).data.finalized.epoch) - 1; // because beacon-API sends previousJustifiedEpoch = finalizedEpoch
 
         // create return data
         currentEpochSlotStatus = {

--- a/launcher/src/backend/ValidatorAccountManager.js
+++ b/launcher/src/backend/ValidatorAccountManager.js
@@ -64,7 +64,7 @@ export class ValidatorAccountManager {
           if (
             latestEpochsResponse.status === 200 &&
             latestEpochsResponse.data.data.length > 0 &&
-            latestEpochsResponse.data.status !== /ERROR:*/
+            latestEpochsResponse.data.status != /ERROR:*/
           ) {
             for (let i = 0; i < 2; i++) {
               if (latestEpochsResponse.data.data[i].status === 1 && isActiveRunning.indexOf(pubkey) === -1) {
@@ -319,7 +319,8 @@ export class ValidatorAccountManager {
     if (!apiToken) apiToken = await this.getApiToken(service);
     let command = [
       "docker run --rm --network=stereum curlimages/curl",
-      `curl ${service.service.includes("Teku") ? "--insecure https" : "http"}://stereum-${service.id}:${validatorPorts[service.service]
+      `curl ${service.service.includes("Teku") ? "--insecure https" : "http"}://stereum-${service.id}:${
+        validatorPorts[service.service]
       }${path}`,
       `-X ${method.toUpperCase()}`,
       `-H 'Content-Type: application/json'`,
@@ -689,7 +690,6 @@ export class ValidatorAccountManager {
       return error;
     }
   }
-
 
   formatImportResult(pubkeys, data) {
     let imported = 0;


### PR DESCRIPTION
fix: https://github.com/stereum-dev/ethereum-node/issues/1451
finalized Epoch from beacon-API is just manually reduced once