### PR TITLE
UPDATE: electron.yaml

### DIFF
--- a/.github/workflows/electron.yaml
+++ b/.github/workflows/electron.yaml
@@ -155,19 +155,19 @@ jobs:
         shell: bash
 
       - name: Download ubuntu binary from build into dist
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@v3
         with:
           name: app-ubuntu-latest
           path: dist
         if: ${{ !contains(github.event.head_commit.message, '[NOCI]') }}
       - name: Download windows binary from build into dist
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@v3
         with:
           name: app-windows-latest
           path: dist
         if: ${{ !contains(github.event.head_commit.message, '[NOCI]') }}
       - name: Download macos binary from build into dist
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@v3
         with:
           name: app-macos-latest
           path: dist

--- a/.github/workflows/electron.yaml
+++ b/.github/workflows/electron.yaml
@@ -155,19 +155,19 @@ jobs:
         shell: bash
 
       - name: Download ubuntu binary from build into dist
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@e9ef242655d12993efdcda9058dee2db83a2cb9b
         with:
           name: app-ubuntu-latest
           path: dist
         if: ${{ !contains(github.event.head_commit.message, '[NOCI]') }}
       - name: Download windows binary from build into dist
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@e9ef242655d12993efdcda9058dee2db83a2cb9b
         with:
           name: app-windows-latest
           path: dist
         if: ${{ !contains(github.event.head_commit.message, '[NOCI]') }}
       - name: Download macos binary from build into dist
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@e9ef242655d12993efdcda9058dee2db83a2cb9b
         with:
           name: app-macos-latest
           path: dist


### PR DESCRIPTION
As It seams do you need to update `actions/download-artifact` together with `actions/upload-artifact`
And as `actions/upload-artifact` is fixed with `v2` and `actions/download-artifact` is always at `master` the versions mismach. https://github.com/actions/download-artifact/issues/267