### PR TITLE
FIX: running image version got lost with new design

### DIFF
--- a/launcher/src/components/UI/node-page/components/logs/LogHeader.vue
+++ b/launcher/src/components/UI/node-page/components/logs/LogHeader.vue
@@ -15,7 +15,7 @@
     <div class="w-full h-full col-start-8 col-end-11 flex justify-center items-center space-x-2">
       <span class="text-sm text-[#dee3e3] font-semibold">{{ $t("pluginLogs.ver") }}</span>
       <span class="text-amber-200 text-md font-semibold">
-        {{ client?.config?.imageVersion }}
+        {{ client?.config?.runningImageVersion }}
       </span>
     </div>
     <div class="w-full h-full col-start-12 col-span-1 flex justify-end items-center">


### PR DESCRIPTION
the image version shown in the header of the logs, was once the actual running image version. this probably got lost in the transition to the new design, so i fixed this in this pr.
