### PR TITLE
Implement Additional Keyboard Shortcuts Across Stereum Features

### DIFF
--- a/launcher/src/components/UI/base-header/components/tabs/TabsBody.vue
+++ b/launcher/src/components/UI/base-header/components/tabs/TabsBody.vue
@@ -19,19 +19,53 @@
 
 <script setup>
 import SingleTab from "./SingleTab.vue";
-import { ref } from "vue";
+import { ref, onMounted, onUnmounted } from "vue";
 import { useFooter } from "@/store/theFooter";
+import { useRouter } from "vue-router";
 import i18n from "@/includes/i18n";
 
 const t = i18n.global.t;
 
-const title = t("shellPage.title");
-
 const footerStore = useFooter();
+const router = useRouter();
+
+const title = t("shellPage.title");
 
 const tabs = ref([
   { page: "Node", path: "/node", relativePath: "/edit" },
   { page: "Control", path: "/control" },
   { page: "Staking", path: "/staking" },
 ]);
+
+const navigateToTab = (path) => {
+  router.push(path);
+};
+
+const handleKeyCombination = (event) => {
+  // Check for both Ctrl (Windows/Linux) and Meta (Cmd on macOS) along with Shift
+  if ((event.ctrlKey || event.metaKey) && event.shiftKey) {
+    switch (event.key.toLowerCase()) {
+      case "n": // Ctrl+Shift+N or Cmd+Shift+N for Node
+        navigateToTab(tabs.value[0].path);
+        break;
+      case "c": // Ctrl+Shift+C or Cmd+Shift+C for Control
+        navigateToTab(tabs.value[1].path);
+        break;
+      case "s": // Ctrl+Shift+S or Cmd+Shift+S for Staking
+        navigateToTab(tabs.value[2].path);
+        break;
+      case "t": // Ctrl+Shift+T or Cmd+Shift+T for Shell
+        navigateToTab("/shell");
+        break;
+    }
+  }
+};
+
+onMounted(() => {
+  window.addEventListener("keydown", handleKeyCombination);
+});
+
+onUnmounted(() => {
+  window.removeEventListener("keydown", handleKeyCombination);
+});
 </script>

--- a/launcher/src/components/UI/base-header/sections/LogoSection.vue
+++ b/launcher/src/components/UI/base-header/sections/LogoSection.vue
@@ -13,7 +13,7 @@
 <script setup>
 import LogoButton from "../../server-management/components/LogoButton.vue";
 import { useFooter } from "@/store/theFooter";
-import { ref, computed } from "vue";
+import { ref, computed, onMounted, onUnmounted } from "vue";
 import i18n from "@/includes/i18n";
 import { useServers } from "@/store/servers";
 import { useRouter } from "vue-router";
@@ -54,4 +54,23 @@ const btnHandler = () => {
     return;
   }
 };
+
+const handleKeyCombination = (event) => {
+  // For macOS, using Cmd+Shift+M
+  const cmdShiftM = event.metaKey && event.shiftKey && event.key === "m";
+  // For Windows/Linux, using Ctrl+Shift+M
+  const ctrlShiftM = event.ctrlKey && event.shiftKey && event.key === "m";
+
+  if (cmdShiftM || ctrlShiftM) {
+    btnHandler();
+  }
+};
+
+onMounted(() => {
+  window.addEventListener("keydown", handleKeyCombination);
+});
+
+onUnmounted(() => {
+  window.removeEventListener("keydown", handleKeyCombination);
+});
 </script>


### PR DESCRIPTION
- [x] Updated keyboard shortcuts to Ctrl+Shift+M / Cmd+Shift+M for handling server access management. 
- [x] Node: Ctrl+Shift+N / Cmd+Shift+N
- [x] Control: Ctrl+Shift+C / Cmd+Shift+C
- [x] Staking: Ctrl+Shift+S / Cmd+Shift+S
- [x] Shell: Ctrl+Shift+T / Cmd+Shift+T
- [x] Help Menu: Activated by Ctrl+Shift+H
- [x] Notifications: Activated by Ctrl+Shift+J
- [x] Available Update: Activated by Ctrl+Shift+U
- [x] Settings: Activated by Ctrl+Shift+G
- [x] Logout: Activated by Ctrl+Shift+L