### PR TITLE
FIX: Validator Import with Password Files

### DIFF
--- a/launcher/src/backend/ValidatorAccountManager.js
+++ b/launcher/src/backend/ValidatorAccountManager.js
@@ -38,10 +38,11 @@ export class ValidatorAccountManager {
 
     for (let i = 0; i < content.length; i += chunkSize) {
       const contentChunk = content.slice(i, i + chunkSize);
+      const passwordChunk = passwords.slice(i, i + chunkSize);
 
       this.batches.push({
         keystores: contentChunk,
-        passwords: passwords,
+        passwords: passwordChunk,
         ...(slashing_protection_content && { slashing_protection: slashing_protection_content }),
       });
     }


### PR DESCRIPTION
If importing more than 100 keys with password files, only the first 100 would be imported. A wrong password batch was assigned for the other batches