### PR TITLE
Fix Naming of Doppelganger to Doppelganger Protection in settings

### DIFF
--- a/launcher/src/store/services.js
+++ b/launcher/src/store/services.js
@@ -117,7 +117,7 @@ export const useServices = defineStore("services", {
               commands: ["--suggested-fee-recipient"],
             },
             {
-              title: "Doppelganger",
+              title: "Doppelganger Protection",
               type: "toggle",
               changeValue: true,
               icon: "/img/icon/service-setting-icons/doppelganger.png",


### PR DESCRIPTION
Change title of option in validator client settings from "Doppelganger" to "Doppelganger Protection"