### PR TITLE
FIX: use yaml dump to write multi setup

### DIFF
--- a/launcher/src/backend/ConfigManager.js
+++ b/launcher/src/backend/ConfigManager.js
@@ -181,7 +181,7 @@ export class ConfigManager {
   async writeMultiSetup(setup) {
     try {
       // Convert the setup object to a YAML string and escape backticks
-      let setupYaml = yaml.safeDump(setup).replace(/`/g, "\\`");
+      let setupYaml = yaml.dump(setup).replace(/`/g, "\\`");
 
       await this.nodeConnection.sshService.exec(`echo -e "${setupYaml}" > ${this.multiSetupPath}`);
     } catch (error) {


### PR DESCRIPTION
- Function yaml.safeDump is removed in js-yaml
- Use yaml.dump instead, which is now safe by default.