### PR TITLE
Typo Update CONTRIBUTING.md

### DIFF
--- a/launcher/CONTRIBUTING.md
+++ b/launcher/CONTRIBUTING.md
@@ -39,7 +39,7 @@ To create your own build you can use `npm run electron:build` and find it in the
 
 If you want to add changes to the global Stereum repository you need to do a pull request.
 
-Pull requests will be reviewed/merged ASAP - please follow this steps:
+Pull requests will be reviewed/merged ASAP - please follow these steps:
 
 1. Open your [local development environment](#getting-started)
 2. Create your feature branch:


### PR DESCRIPTION
### Fix Typographical Error in Contribution Guide

I found a typographical issue in the "Pull Requests" section of the contribution guide.

#### Issue:
In the sentence:

> "Pull requests will be reviewed/merged ASAP - please follow **this** steps:"

The word "**this**" should be changed to "**these**" to properly agree with the plural noun "steps."

#### Fix:
The corrected sentence is:

> "Pull requests will be reviewed/merged ASAP - please follow **these** steps:"

This is a minor issue, but correcting it ensures proper grammar and clarity in the contribution guide. This change enhances the readability and professionalism of the documentation.
