### PR TITLE
Fix error in log message Update NodeUpdates.js

### DIFF
--- a/launcher/src/backend/NodeUpdates.js
+++ b/launcher/src/backend/NodeUpdates.js
@@ -140,7 +140,7 @@ export class NodeUpdates {
       const res = await this.nodeConnection.sshService.exec(`lsb_release -d | awk '{print $3}'`);
       return res.stdout;
     } catch (err) {
-      log.error("Error occurred during get count pd updating os packages:\n", err);
+      log.error("Error occurred during get count of updating OS packages:\n", err);
     }
   }
 
@@ -154,7 +154,7 @@ export class NodeUpdates {
 
       return res.stdout;
     } catch (err) {
-      log.error("Error occurred during get count pd updating os packages:\n", err);
+      log.error("Error occurred during get count of updating OS packages:\n", err);
     }
   }
 


### PR DESCRIPTION
**Description**:
This pull request fixes an issue in the log message where the text `"get count pd updating os packages"` was incorrectly used. The intended message is `"get count of updating OS packages"`. This error occurred in two methods: `getCurrentOsVersion` and `getCountOfUpdatableOSUpdate`.

**Changes made**:
- Updated the log message in both methods to reflect the correct phrasing: `"Error occurred during get count of updating OS packages:\n"`

**Importance**:
Correcting this log message improves the clarity of error reporting. The original message was unclear due to the use of "pd" instead of the correct phrase, which could cause confusion when debugging. This fix ensures that the log provides accurate and understandable information about errors during the process of counting OS package updates.