### PR TITLE
docs: Fix typo in command and correct spelling

### DIFF
--- a/controls/README.md
+++ b/controls/README.md
@@ -1,6 +1,6 @@
 # Molecule Test Environment
 ## Requirements
-You'll need to have `docker` and `python` with `pip` intalled. You can then install poetry with the following command:
+You'll need to have `docker` and `python` with `pip` installed. You can then install poetry with the following command:
 ```bash
 pip install poetry
 ```
@@ -31,7 +31,7 @@ export HCLOUD_TOKEN=<YOUR_API_TOKEN> # on macOS and Linux
 To run tests, cd into `./roles/<role-to-test>` and run:
 ```bash
 molecule test
-molcule test -s <scenario-name>
+molecule test -s <scenario-name>
 ```
 ### Extra Information
 - The roles `update-changes`, `configure-updates` and `configure-firewall` use the `docker` driver. This means that the tests will run in a docker container on your machine. Therefore, you'll need to have docker installed and running.


### PR DESCRIPTION
I noticed a typo in the command `molcule test -s <scenario-name>`.
The correct spelling should be `molecule`. I've fixed this in the documentation.  

Additionally, I corrected a small spelling mistake in the sentence: "You'll need to have docker and python with pip intalled." 
The word "intalled" should be "installed."  
