### PR TITLE
docs: Fix incorrect command in documentation Update CONTRIBUTING.md

### DIFF
--- a/launcher/CONTRIBUTING.md
+++ b/launcher/CONTRIBUTING.md
@@ -44,7 +44,7 @@ Pull requests will be reviewed/merged ASAP - please follow these steps:
 1. Open your [local development environment](#getting-started)
 2. Create your feature branch:
    - `git checkout -b feat/new-feature`
-3. Use `npm run format:check` to check the format of your code and `run npm run format` to format your code
+3. Use `npm run format:check` to check the format of your code and `npm run format` to format your code
 4. Commit your changes:
    - `git commit -m "feat(optional): new feature"`
 5. Push the branch:


### PR DESCRIPTION
A typo in the documentation where the command `run npm run format` was incorrectly written.
The extra `run` before `npm` has been removed, so the correct command is now `npm run format`.