### PR TITLE
CHANGE: apple_id_password with apple_app_specific_password

### DIFF
--- a/.github/workflows/electron.yaml
+++ b/.github/workflows/electron.yaml
@@ -79,7 +79,7 @@ jobs:
           args: ${{ env.BUILD_ARGS }}
         env:
           APPLE_ID: ${{ secrets.apple_id }}
-          APPLE_ID_PASSWORD: ${{ secrets.apple_id_password }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.apple_app_specific_password }}
           TEAM_SHORT_NAME: ${{ secrets.team_short_name }}
           APP_ID: "com.stereum.launcher"
           TEAM_ID: ${{ secrets.team_id }}


### PR DESCRIPTION
we'll need to do this: https://support.apple.com/en-us/102654 and include the password in our secrets with the key `apple_app_specific_password`

this replaces `apple_id_password` used previously