### PR TITLE
fix: incorrect usage of `vue-loader` and `css-loader` in Webpack config

### DIFF
--- a/launcher/vue.config.js
+++ b/launcher/vue.config.js
@@ -41,13 +41,7 @@ module.exports = {
 
   chainWebpack: (config) => {
     config.resolve.alias.set("vue-i18n", "vue-i18n/dist/vue-i18n.cjs.js");
-    config.module
-      .rule("vue")
-      .use("vue-loader")
-      .loader("vue-loader")
-      .end()
-      .use("css-loader")
-      .loader("css-loader");
+    config.module.rule("vue").use("vue-loader").loader("vue-loader").end().use("css-loader").loader("css-loader");
     config.plugin("define").tap((definitions) => {
       Object.assign(definitions[0], {
         __VUE_OPTIONS_API__: "true",

--- a/launcher/vue.config.js
+++ b/launcher/vue.config.js
@@ -41,7 +41,13 @@ module.exports = {
 
   chainWebpack: (config) => {
     config.resolve.alias.set("vue-i18n", "vue-i18n/dist/vue-i18n.cjs.js");
-    config.module.rule("vue").use("vue-loader", "css-loader");
+    config.module
+      .rule("vue")
+      .use("vue-loader")
+      .loader("vue-loader")
+      .end()
+      .use("css-loader")
+      .loader("css-loader");
     config.plugin("define").tap((definitions) => {
       Object.assign(definitions[0], {
         __VUE_OPTIONS_API__: "true",


### PR DESCRIPTION
I corrected an issue where the `vue-loader` and `css-loader` were being applied incorrectly in the Webpack config.
Instead of passing them as two parameters, I’ve updated it to use an array, which is the proper way to define multiple loaders in Webpack. This should fix the issue and ensure that the loaders are applied properly.