### PR TITLE
Revert "fix: incorrect usage of `vue-loader` and `css-loader` in Webpack config"

### DIFF
--- a/launcher/vue.config.js
+++ b/launcher/vue.config.js
@@ -41,7 +41,7 @@ module.exports = {
 
   chainWebpack: (config) => {
     config.resolve.alias.set("vue-i18n", "vue-i18n/dist/vue-i18n.cjs.js");
-    config.module.rule("vue").use("vue-loader").loader("vue-loader").end().use("css-loader").loader("css-loader");
+    config.module.rule("vue").use("vue-loader", "css-loader");
     config.plugin("define").tap((definitions) => {
       Object.assign(definitions[0], {
         __VUE_OPTIONS_API__: "true",


### PR DESCRIPTION
Reverts stereum-dev/ethereum-node#2242