### PR TITLE
FIX: 2FA remove issue on ubuntu-24.04

### DIFF
--- a/controls/roles/2fa-remove/tasks/main.yaml
+++ b/controls/roles/2fa-remove/tasks/main.yaml
@@ -36,7 +36,15 @@
     state: absent
   ignore_errors: yes
 
+- name: Set SSH service name depending on distribution and version
+  set_fact:
+    ssh_service_name: >-
+      {{ 'ssh'
+         if (ansible_facts['distribution'] == 'Ubuntu'
+             and ansible_facts['distribution_version'] is version('20.04', '>='))
+         else 'sshd' }}
+
 - name: Restart SSH service
   systemd:
-    name: sshd
+    name: "{{ ssh_service_name }}"
     state: restarted


### PR DESCRIPTION
Fixes an issue when removing 2FA on Ubtuntu 24.04

Same as #2246 but for the "2fa-remove" task.