### PR TITLE
 Remove `data` wrapper from exported voluntary-exit messages

### DIFF
--- a/launcher/src/components/UI/staking-page/StakingScreen.vue
+++ b/launcher/src/components/UI/staking-page/StakingScreen.vue
@@ -612,8 +612,15 @@ const exportExitMessage = async () => {
 };
 
 const saveExitMessage = (data, type) => {
+  // Helper to strip a potential `data` wrapper returned by the API
+  const unwrap = (entry) => (entry && entry.data ? entry.data : entry);
+
   const content =
-    type === "single" ? JSON.stringify(data.data, null, 2) : data.map((entry) => JSON.stringify(entry.data, null, 2)).join("\n\n");
+    type === "single"
+      ? JSON.stringify(unwrap(data), null, 2)
+      : data
+          .map((entry) => JSON.stringify(unwrap(entry), null, 2))
+          .join("\n\n");
 
   const fileName = type === "single" ? "single_exit_message.txt" : "multiple_exit_messages.txt";
   const blob = new Blob([content], { type: "application/json;charset=utf-8" });


### PR DESCRIPTION

### PR Description 

When users export a signed voluntary-exit message, the file currently contains the entire response object (wrapped in a `data` property).  
This PR cleans up the export so that **only the raw exit message JSON is saved**, with no surrounding `data` wrapper—both for single- and multi-validator exports.

Key change  
• `saveExitMessage()` now strips any optional `data` field before writing the file.

fixes #2255 
