### PR TITLE
ADD: dev lane for updates.json

### DIFF
--- a/controls/roles/update-services/tasks/main.yml
+++ b/controls/roles/update-services/tasks/main.yml
@@ -1,7 +1,11 @@
 ---
+- name: Set lane suffix
+  set_fact:
+    updates_lane_suffix: "{{ '.dev' if (stereum.settings.updates.lane | default('stable')) == 'dev' else '' }}"
+
 - name: Download update metadata
   uri:
-    url: https://stereum.net/downloads/updates.json
+    url: "https://stereum.net/downloads/updates{{ updates_lane_suffix }}.json"
     method: GET
     return_content: yes
     status_code: 200
@@ -26,5 +30,4 @@
 - name: Update services
   include_tasks: update-service.yml
   with_items: "{{ services_to_update }}"
-
 # EOF

--- a/controls/roles/update-stereum/tasks/main.yml
+++ b/controls/roles/update-stereum/tasks/main.yml
@@ -5,9 +5,13 @@
     state: absent
   become: yes
 
+- name: Set lane suffix
+  set_fact:
+    updates_lane_suffix: "{{ '.dev' if (stereum.settings.updates.lane | default('stable')) == 'dev' else '' }}"
+
 - name: Download update metadata
   uri:
-    url: https://stereum.net/downloads/updates.json
+    url: "https://stereum.net/downloads/updates{{ updates_lane_suffix }}.json"
     method: GET
     return_content: true
     status_code: 200

--- a/launcher/src/backend/NodeConnection.js
+++ b/launcher/src/backend/NodeConnection.js
@@ -29,6 +29,7 @@ export class NodeConnection {
     this.nodeConnectionParams = nodeConnectionParams;
     this.os = null;
     this.osv = null;
+    this.settings = null;
     this.nodeUpdates = new NodeUpdates(this);
     this.configManager = new ConfigManager(this);
   }

--- a/launcher/src/backend/NodeUpdates.js
+++ b/launcher/src/backend/NodeUpdates.js
@@ -37,7 +37,11 @@ export class NodeUpdates {
    * @returns {Object} - updates available for services
    */
   async checkUpdates() {
-    let response = await axios.get("https://stereum.net/downloads/updates.json");
+    if (!this.nodeConnection?.settings?.lane) {
+      await this.nodeConnection.findStereumSettings();
+    }
+    const lane = this.nodeConnection?.settings?.lane || "stable";
+    let response = await axios.get(`https://stereum.net/downloads/updates${lane == "dev" ? ".dev" : ""}.json`);
     if (global.branch === "main") response.data.stereum.push({ name: "HEAD", commit: "main" });
     return response.data;
   }

--- a/launcher/src/backend/NodeUpdates.js
+++ b/launcher/src/backend/NodeUpdates.js
@@ -37,10 +37,10 @@ export class NodeUpdates {
    * @returns {Object} - updates available for services
    */
   async checkUpdates() {
-    if (!this.nodeConnection?.settings?.lane) {
+    if (!this.nodeConnection.settings?.stereum?.settings?.updates?.lane) {
       await this.nodeConnection.findStereumSettings();
     }
-    const lane = this.nodeConnection?.settings?.lane || "stable";
+    const lane = this.nodeConnection.settings?.stereum?.settings?.updates?.lane || "stable";
     let response = await axios.get(`https://stereum.net/downloads/updates${lane == "dev" ? ".dev" : ""}.json`);
     if (global.branch === "main") response.data.stereum.push({ name: "HEAD", commit: "main" });
     return response.data;


### PR DESCRIPTION
makes use of the `lane` setting in the `stereum settings`.

values:
- `dev` will fetch `updates.dev.json`
- `prod (or anything else bc default)` will fetch `updates.json`