### PR TITLE
FIX: grandine sync status

### DIFF
--- a/launcher/src/backend/Monitoring.js
+++ b/launcher/src/backend/Monitoring.js
@@ -1114,7 +1114,7 @@ export class Monitoring {
         PrysmBeaconService: ["beacon_clock_time_slot", "beacon_head_slot"], // OK - query for job="prysm_beacon"!
         NimbusBeaconService: ["beacon_slot", "beacon_head_slot"], // OK - query for job="nimbus"
         LodestarBeaconService: ["beacon_clock_slot", "beacon_head_slot"], // OK - query for job="lodestar_beacon"
-        // GrandineBeaconService: ["", "beacon_head_slot"], // NOT OK Current Slot is not available - query for job="grandine_beacon"
+        GrandineBeaconService: ["beacon_head_slot", "beacon_head_slot"], // NOT OK Current Slot (based on genesis time and clock) is not available - query for job="grandine_beacon"
       },
       execution: {
         GethService: ["chain_head_header", "chain_head_block"], // OK - query for job="geth"
@@ -1128,7 +1128,7 @@ export class Monitoring {
 
     // Prometheus job definitions
     const jobs = {
-      //GrandineBeaconService: "grandine_beacon",
+      GrandineBeaconService: "grandine_beacon",
       TekuBeaconService: "teku_beacon",
       LighthouseBeaconService: "lighthouse_beacon",
       PrysmBeaconService: "prysm_beacon",


### PR DESCRIPTION
Issue is that grandine does not have a metric that shows the current slot based on genesis time and current time, which leaves us with these options:

- make a similar thing as for the execution clients (getting sync status via RPC) and use the beacon api
- - this can be done by calling an existing function to get the current slot
- - or by directly calling the `/eth/v1/node/syncing` endpoint
- wait for grandine to implement this metric
- just show 100% with `beacon_head_slot` to ensure sync status is loading at all

i went with the latest as implementing this would take me (and probably dave as well) quite some time
