### PR TITLE
chore(ci): upgrade checkout to v5

### DIFF
--- a/.github/workflows/code_quality_check.yml
+++ b/.github/workflows/code_quality_check.yml
@@ -11,7 +11,7 @@ jobs:
     name: Prettier
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: "20"

--- a/.github/workflows/electron.yaml
+++ b/.github/workflows/electron.yaml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Ensure Node Version
         uses: actions/setup-node@v4
@@ -155,7 +155,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Set Versions
         id: variables
@@ -218,3 +218,4 @@ jobs:
         run: |
           gh release upload --clobber "${{ steps.variables.outputs.version }}-draft" dist/*
         if: ${{ !contains(github.event.head_commit.message, '[NOCI]') && !contains(github.event.head_commit.message, '[DRAFT]') }}
+

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
   ESLint-test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: "20"

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -13,6 +13,6 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master

--- a/.github/workflows/test-integration-legacy.yml
+++ b/.github/workflows/test-integration-legacy.yml
@@ -11,7 +11,7 @@ jobs:
       ELTests: ${{ steps.get-EL-tests.outputs.tests }}
       otherTests: ${{ steps.get-other-tests.outputs.tests }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: "19"
@@ -41,7 +41,7 @@ jobs:
       matrix:
         test: ${{ fromJson(needs.setup.outputs.importTests) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: "19"
@@ -63,7 +63,7 @@ jobs:
       matrix:
         test: ${{ fromJson(needs.setup.outputs.ELTests) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: "19"
@@ -84,7 +84,7 @@ jobs:
       matrix:
         test: ${{ fromJson(needs.setup.outputs.otherTests) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: "19"

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -14,7 +14,7 @@ jobs:
       - Other-Integration-test
       - Execution-Client-test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
@@ -32,7 +32,7 @@ jobs:
     needs:
       - Other-Integration-test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-24.04
     name: Other Integration Tests
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: "22"

--- a/.github/workflows/test-jest.yml
+++ b/.github/workflows/test-jest.yml
@@ -12,7 +12,7 @@ jobs:
   jest-test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: "20"

--- a/.github/workflows/test-molecule.yml
+++ b/.github/workflows/test-molecule.yml
@@ -18,7 +18,7 @@ jobs:
     concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -77,7 +77,7 @@ jobs:
     concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -130,7 +130,7 @@ jobs:
     concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -183,7 +183,7 @@ jobs:
     concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -236,7 +236,7 @@ jobs:
     concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -289,7 +289,7 @@ jobs:
     concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -345,7 +345,7 @@ jobs:
   #   concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
   #   runs-on: ubuntu-22.04
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v5
   #     - name: Set up Python
   #       uses: actions/setup-python@v4
   #       with:
@@ -398,7 +398,7 @@ jobs:
     concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -503,7 +503,7 @@ jobs:
     concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -558,7 +558,7 @@ jobs:
     concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -617,7 +617,7 @@ jobs:
     concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -677,7 +677,7 @@ jobs:
     concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
Bumps checkout to v5 for future-proofing against Node 24 runner updates.
Requires runner v2.327.1+. Workflows compile the same.

Ref: https://github.com/actions/checkout/releases/tag/v5.0.0