### PR TITLE
ADD: Geth Update Script

### DIFF
--- a/controls/roles/update-changes/molecule/246/prepare.yml
+++ b/controls/roles/update-changes/molecule/246/prepare.yml
@@ -96,4 +96,77 @@
         group: "2000"
         mode: 0644
       become: yes
+
+    - name: Create GethService config
+      copy:
+        dest: "/etc/stereum/services/ea7db2eb-98d3-dd11-efad-e34df35350d8.yaml"
+        owner: "root"
+        group: "root"
+        mode: 0644
+        content: |
+          service: GethService
+          id: ea7db2eb-98d3-dd11-efad-e34df35350d8
+          configVersion: 1
+          command:
+            - --hoodi
+            - --state.scheme=path
+            - --http
+            - --http.api=eth,web3,net
+            - --http.port=8545
+            - --http.addr=0.0.0.0
+            - --http.corsdomain=*
+            - --http.vhosts=*
+            - --ws
+            - --ws.api=eth,net,web3
+            - --ws.port=8546
+            - --ws.addr=0.0.0.0
+            - --ws.origins=*
+            - --authrpc.port=8551
+            - --authrpc.vhosts=*
+            - --authrpc.addr=0.0.0.0
+            - --authrpc.jwtsecret=/engine.jwt
+            - --datadir=/opt/data/geth
+            - --metrics
+            - --metrics.expensive
+            - --metrics.port=6060
+            - --metrics.addr=0.0.0.0
+          entrypoint:
+            - geth
+          env: {}
+          image: ethereum/client-go:v1.17.0
+          ports:
+            - 127.0.0.1:8545:8545/tcp
+            - 127.0.0.1:8546:8546/tcp
+            - 0.0.0.0:30303:30303/tcp
+            - 0.0.0.0:30303:30303/udp
+          volumes:
+            - /opt/stereum/geth-ea7db2eb-98d3-dd11-efad-e34df35350d8/data:/opt/data/geth
+            - /opt/stereum/geth-ea7db2eb-98d3-dd11-efad-e34df35350d8/engine.jwt:/engine.jwt
+          user: root
+          autoupdate: true
+          network: hoodi
+          dependencies:
+            executionClients: []
+            consensusClients: []
+            mevboost: []
+            otherServices: []
+      become: yes
+
+    - name: ensure geth data directory exists
+      file:
+        path: "/opt/stereum/geth-ea7db2eb-98d3-dd11-efad-e34df35350d8/data/geth"
+        state: directory
+        owner: "2000"
+        group: "2000"
+        mode: 0755
+      become: yes
+
+    - name: create nodekey file for geth
+      file:
+        path: "/opt/stereum/geth-ea7db2eb-98d3-dd11-efad-e34df35350d8/data/geth/nodekey"
+        state: touch
+        owner: "2000"
+        group: "2000"
+        mode: 0755
+      become: yes
 # EOF

--- a/controls/roles/update-changes/molecule/246/verify.yml
+++ b/controls/roles/update-changes/molecule/246/verify.yml
@@ -9,20 +9,33 @@
         src: "/etc/stereum/services/353b6184-928a-b686-31b4-f4db2073224a.yaml"
       register: Teku_service_configuration_raw
 
+    # GethService
+    - name: Read GethService file
+      slurp:
+        src: "/etc/stereum/services/ea7db2eb-98d3-dd11-efad-e34df35350d8.yaml"
+      register: Geth_service_configuration_raw
+
     - name: Parse Service configurations
       set_fact:
         Teku_service_configuration: "{{ Teku_service_configuration_raw['content'] | b64decode | from_yaml }}"
-        data_volume: "/opt/stereum/teku-353b6184-928a-b686-31b4-f4db2073224a/data"
+        Geth_service_configuration: "{{ Geth_service_configuration_raw['content'] | b64decode | from_yaml }}"
+        teku_data_volume: "/opt/stereum/teku-353b6184-928a-b686-31b4-f4db2073224a/data"
+        geth_data_volume: "/opt/stereum/geth-ea7db2eb-98d3-dd11-efad-e34df35350d8/data"
 
     - name: check if db version file exists
       stat:
-        path: "{{ data_volume }}/beacon/db.version"
+        path: "{{ teku_data_volume }}/beacon/db.version"
       register: db_version_file
 
     - name: check if db dir exists
       stat:
-        path: "{{ data_volume }}/beacon/db"
+        path: "{{ teku_data_volume }}/beacon/db"
       register: db_dir
+
+    - name: check if nodekey file exists
+      stat:
+        path: "{{ geth_data_volume }}/geth/nodekey"
+      register: nodekey_file
 
     - debug:
         msg: "{{ Teku_service_configuration }}"
@@ -31,10 +44,18 @@
     - debug:
         msg: "db version file exists: {{ db_version_file.stat.exists }}, db dir exists: {{ db_dir.stat.exists }}"
 
+    - debug:
+        msg: "{{ Geth_service_configuration }}"
+    - debug:
+        msg: "{{ Geth_service_configuration_raw['content'] | b64decode }}"
+    - debug:
+        msg: "nodekey file exists: {{ nodekey_file.stat.exists }}"
+
     - assert:
         that:
           - Teku_service_configuration.command | select('match', '--Xp2p-reworked-sidecar-recovery-enabled') | length == 0
           - Teku_service_configuration.command | select('match', '--Xdata-storage-create-db-version=6') | length == 0
           - db_version_file.stat.exists == false
           - db_dir.stat.exists == false
+          - nodekey_file.stat.exists == false
 # EOF

--- a/controls/roles/update-changes/tasks/2.4.6/geth_changes.yaml
+++ b/controls/roles/update-changes/tasks/2.4.6/geth_changes.yaml
@@ -1,0 +1,41 @@
+---
+- name: Read service file
+  slurp:
+    src: "{{ config_file.path }}"
+  register: service_configuration_raw
+
+- name: Parse service's configuration
+  set_fact:
+    service_configuration: "{{ service_configuration_raw['content'] | b64decode | from_yaml }}"
+    service_configuration_text: "{{ service_configuration_raw['content'] | b64decode }}"
+
+- name: Geth Changes
+  when: service_configuration.service == "GethService"
+  block:
+    - name: get data volume name
+      set_fact:
+        data_volume: "{{ service_configuration.volumes | select('search', service_configuration.id) | select('search', '/data') | first | split(':') | first }}"
+
+    - name: get geth version
+      set_fact:
+        geth_version: "{{ service_configuration.image | split(':') | last }}"
+
+    - debug:
+        msg: "Geth version: {{ geth_version }}"
+
+    - name: decide if nodekey needs to be removed
+      set_fact:
+        remove_nodekey: "{{ geth_version is version('v1.16.0', '>=') and geth_version is version('v1.17.0', '<=') }}"
+
+    - name: delete nodekey file
+      when: remove_nodekey
+      file:
+        path: "{{ data_volume }}/geth/nodekey"
+        state: absent
+
+    - name: touch service config file to trigger service restart
+      when: remove_nodekey
+      file:
+        path: "{{ config_file.path }}"
+        state: touch
+      changed_when: false # to pass idempotence test

--- a/controls/roles/update-changes/tasks/2.4.6/updates-246.yaml
+++ b/controls/roles/update-changes/tasks/2.4.6/updates-246.yaml
@@ -9,3 +9,9 @@
   loop: "{{ service_config_files.files }}"
   loop_control:
     loop_var: config_file
+
+- name: Include Geth Changes
+  include_tasks: geth_changes.yaml
+  loop: "{{ service_config_files.files }}"
+  loop_control:
+    loop_var: config_file


### PR DESCRIPTION
Added update script for geth so versions between 1.16.0 and 1.17.0 remove the nodekey on update (update-changes is triggered on Stereum (Ansible) Update and when hitting update all which triggers Stereum Update)