### PR TITLE
FIX: macos build

### DIFF
--- a/launcher/afterPackMac.js
+++ b/launcher/afterPackMac.js
@@ -9,10 +9,7 @@ const path = require("path");
 exports.default = async function afterPackMac(context) {
   if (context.electronPlatformName !== "darwin") return;
 
-  const appPath = path.join(
-    context.appOutDir,
-    `${context.packager.appInfo.productFilename}.app`
-  );
+  const appPath = path.join(context.appOutDir, `${context.packager.appInfo.productFilename}.app`);
 
   console.log(`[afterPackMac] Ad-hoc re-signing for macOS 26+ Team ID compatibility:`);
   console.log(`[afterPackMac] ${appPath}`);

--- a/launcher/afterPackMac.js
+++ b/launcher/afterPackMac.js
@@ -1,0 +1,23 @@
+const { execSync } = require("child_process");
+const path = require("path");
+
+// electron-builder v26 no longer re-signs bundled frameworks when no certificate is
+// provided. The Electron Framework ships pre-signed with the Electron project's Apple
+// Team ID, causing macOS 26+ to reject the load because the main executable has no
+// Team ID. Re-sign everything with ad-hoc ("-") so all binaries share a consistent
+// (empty) Team ID and dyld's validation passes.
+exports.default = async function afterPackMac(context) {
+  if (context.electronPlatformName !== "darwin") return;
+
+  const appPath = path.join(
+    context.appOutDir,
+    `${context.packager.appInfo.productFilename}.app`
+  );
+
+  console.log(`[afterPackMac] Ad-hoc re-signing for macOS 26+ Team ID compatibility:`);
+  console.log(`[afterPackMac] ${appPath}`);
+
+  execSync(`codesign --force --deep --sign - "${appPath}"`, { stdio: "inherit" });
+
+  console.log(`[afterPackMac] Done.`);
+};

--- a/launcher/vue.config.js
+++ b/launcher/vue.config.js
@@ -1,4 +1,5 @@
 const shouldNotarize = process.env.NOTARIZE === "true";
+const isSigned = process.env.CSC_IDENTITY_AUTO_DISCOVERY !== "false";
 module.exports = {
   parallel: false,
   pluginOptions: {
@@ -12,6 +13,7 @@ module.exports = {
         appId: "com.stereum.launcher",
         productName: "Stereum-Launcher",
         ...(shouldNotarize ? { afterSign: "@sapien99/vue-cli-plugin-electron-builder-notarize" } : {}),
+        ...(!isSigned ? { afterPack: "./afterPackMac.js" } : {}),
         buildDependenciesFromSource: false,
         nodeGypRebuild: false,
         npmRebuild: false,
@@ -27,8 +29,18 @@ module.exports = {
           artifactName: "Stereum-Launcher-${version}.${ext}",
         },
         mac: {
-          hardenedRuntime: true,
-          entitlements: "./node_modules/@sapien99/vue-cli-plugin-electron-builder-notarize/entitlements.mac.inherit.plist",
+          // hardenedRuntime requires consistent Team IDs across all binaries; only enable
+          // when actually signing, otherwise the Electron Framework's pre-signed Team ID
+          // differs from the unsigned main binary and dyld refuses to load it (macOS 14.4+)
+          hardenedRuntime: isSigned,
+          ...(isSigned
+            ? {
+                entitlements:
+                  "./node_modules/@sapien99/vue-cli-plugin-electron-builder-notarize/entitlements.mac.inherit.plist",
+                entitlementsInherit:
+                  "./node_modules/@sapien99/vue-cli-plugin-electron-builder-notarize/entitlements.mac.inherit.plist",
+              }
+            : {}),
           gatekeeperAssess: false,
           artifactName: "Stereum-Launcher-${version}.${ext}",
           x64ArchFiles: "**/*.node",

--- a/launcher/vue.config.js
+++ b/launcher/vue.config.js
@@ -35,10 +35,8 @@ module.exports = {
           hardenedRuntime: isSigned,
           ...(isSigned
             ? {
-                entitlements:
-                  "./node_modules/@sapien99/vue-cli-plugin-electron-builder-notarize/entitlements.mac.inherit.plist",
-                entitlementsInherit:
-                  "./node_modules/@sapien99/vue-cli-plugin-electron-builder-notarize/entitlements.mac.inherit.plist",
+                entitlements: "./node_modules/@sapien99/vue-cli-plugin-electron-builder-notarize/entitlements.mac.inherit.plist",
+                entitlementsInherit: "./node_modules/@sapien99/vue-cli-plugin-electron-builder-notarize/entitlements.mac.inherit.plist",
               }
             : {}),
           gatekeeperAssess: false,


### PR DESCRIPTION
## FIX: macOS build

Fixes the unsigned macOS build, which was failing to launch on macOS 14.4+ / macOS 26 due to inconsistent Team IDs between the (pre-signed) Electron Framework and the unsigned main binary, causing dyld to reject the load.

### Background
electron-builder v26 no longer re-signs bundled frameworks when no signing certificate is provided. The Electron Framework ships pre-signed with the Electron project's Apple Team ID, while the main executable has no Team ID — dyld's validation refuses to load the app as a result.

### Changes

**`launcher/afterPackMac.js`** (new file)
- Adds an `afterPack` hook that runs only on `darwin`.
- Ad-hoc re-signs the entire `.app` bundle with `codesign --force --deep --sign -`, so all binaries share a consistent (empty) Team ID and dyld validation passes.

**`launcher/vue.config.js`**
- Introduces `isSigned` flag derived from `CSC_IDENTITY_AUTO_DISCOVERY !== "false"`.
- Wires up the new `afterPackMac.js` hook only for unsigned builds.
- `hardenedRuntime` is now conditional on `isSigned` — it requires consistent Team IDs across binaries and only makes sense when actually signing.
- `entitlements` / `entitlementsInherit` are likewise only set on signed builds.

### Result
- Signed/notarized builds: behavior unchanged.
- Unsigned local/CI builds: app launches correctly on macOS 14.4+ and macOS 26+.