### PR TITLE
FIX: github workflow macos build

### DIFF
--- a/launcher/afterPackMac.js
+++ b/launcher/afterPackMac.js
@@ -9,10 +9,7 @@ const path = require("path");
 exports.default = async function afterPackMac(context) {
   if (context.electronPlatformName !== "darwin") return;
 
-  const appPath = path.join(
-    context.appOutDir,
-    `${context.packager.appInfo.productFilename}.app`
-  );
+  const appPath = path.join(context.appOutDir, `${context.packager.appInfo.productFilename}.app`);
 
   console.log(`[afterPackMac] Ad-hoc re-signing for macOS 26+ Team ID compatibility:`);
   console.log(`[afterPackMac] ${appPath}`);

--- a/launcher/afterPackMac.js
+++ b/launcher/afterPackMac.js
@@ -1,0 +1,23 @@
+const { execSync } = require("child_process");
+const path = require("path");
+
+// electron-builder v26 no longer re-signs bundled frameworks when no certificate is
+// provided. The Electron Framework ships pre-signed with the Electron project's Apple
+// Team ID, causing macOS 26+ to reject the load because the main executable has no
+// Team ID. Re-sign everything with ad-hoc ("-") so all binaries share a consistent
+// (empty) Team ID and dyld's validation passes.
+exports.default = async function afterPackMac(context) {
+  if (context.electronPlatformName !== "darwin") return;
+
+  const appPath = path.join(
+    context.appOutDir,
+    `${context.packager.appInfo.productFilename}.app`
+  );
+
+  console.log(`[afterPackMac] Ad-hoc re-signing for macOS 26+ Team ID compatibility:`);
+  console.log(`[afterPackMac] ${appPath}`);
+
+  execSync(`codesign --force --deep --sign - "${appPath}"`, { stdio: "inherit" });
+
+  console.log(`[afterPackMac] Done.`);
+};

--- a/launcher/afterSignMac.js
+++ b/launcher/afterSignMac.js
@@ -6,15 +6,21 @@ const path = require("path");
 // Team ID, causing macOS 26+ to reject the load because the main executable has no
 // Team ID. Re-sign everything with ad-hoc ("-") so all binaries share a consistent
 // (empty) Team ID and dyld's validation passes.
-exports.default = async function afterPackMac(context) {
+//
+// This must be afterSign (not afterPack) for --universal builds: afterPack fires once
+// per arch on the temporary per-arch outputs before @electron/universal merges them.
+// Re-signing those temps makes CodeResources differ between architectures, causing the
+// merge to fail with "non-binary files have different SHAs". afterSign fires once on
+// the final merged universal .app, after the merge succeeds.
+exports.default = async function afterSignMac(context) {
   if (context.electronPlatformName !== "darwin") return;
 
   const appPath = path.join(context.appOutDir, `${context.packager.appInfo.productFilename}.app`);
 
-  console.log(`[afterPackMac] Ad-hoc re-signing for macOS 26+ Team ID compatibility:`);
-  console.log(`[afterPackMac] ${appPath}`);
+  console.log(`[afterSignMac] Ad-hoc re-signing for macOS 26+ Team ID compatibility:`);
+  console.log(`[afterSignMac] ${appPath}`);
 
   execSync(`codesign --force --deep --sign - "${appPath}"`, { stdio: "inherit" });
 
-  console.log(`[afterPackMac] Done.`);
+  console.log(`[afterSignMac] Done.`);
 };

--- a/launcher/vue.config.js
+++ b/launcher/vue.config.js
@@ -12,8 +12,11 @@ module.exports = {
         },
         appId: "com.stereum.launcher",
         productName: "Stereum-Launcher",
-        ...(shouldNotarize ? { afterSign: "@sapien99/vue-cli-plugin-electron-builder-notarize" } : {}),
-        ...(!isSigned ? { afterPack: "./afterPackMac.js" } : {}),
+        ...(shouldNotarize
+          ? { afterSign: "@sapien99/vue-cli-plugin-electron-builder-notarize" }
+          : !isSigned
+            ? { afterSign: "./afterSignMac.js" }
+            : {}),
         buildDependenciesFromSource: false,
         nodeGypRebuild: false,
         npmRebuild: false,

--- a/launcher/vue.config.js
+++ b/launcher/vue.config.js
@@ -1,4 +1,5 @@
 const shouldNotarize = process.env.NOTARIZE === "true";
+const isSigned = process.env.CSC_IDENTITY_AUTO_DISCOVERY !== "false";
 module.exports = {
   parallel: false,
   pluginOptions: {
@@ -12,6 +13,7 @@ module.exports = {
         appId: "com.stereum.launcher",
         productName: "Stereum-Launcher",
         ...(shouldNotarize ? { afterSign: "@sapien99/vue-cli-plugin-electron-builder-notarize" } : {}),
+        ...(!isSigned ? { afterPack: "./afterPackMac.js" } : {}),
         buildDependenciesFromSource: false,
         nodeGypRebuild: false,
         npmRebuild: false,
@@ -27,8 +29,18 @@ module.exports = {
           artifactName: "Stereum-Launcher-${version}.${ext}",
         },
         mac: {
-          hardenedRuntime: true,
-          entitlements: "./node_modules/@sapien99/vue-cli-plugin-electron-builder-notarize/entitlements.mac.inherit.plist",
+          // hardenedRuntime requires consistent Team IDs across all binaries; only enable
+          // when actually signing, otherwise the Electron Framework's pre-signed Team ID
+          // differs from the unsigned main binary and dyld refuses to load it (macOS 14.4+)
+          hardenedRuntime: isSigned,
+          ...(isSigned
+            ? {
+                entitlements:
+                  "./node_modules/@sapien99/vue-cli-plugin-electron-builder-notarize/entitlements.mac.inherit.plist",
+                entitlementsInherit:
+                  "./node_modules/@sapien99/vue-cli-plugin-electron-builder-notarize/entitlements.mac.inherit.plist",
+              }
+            : {}),
           gatekeeperAssess: false,
           artifactName: "Stereum-Launcher-${version}.${ext}",
           x64ArchFiles: "**/*.node",

--- a/launcher/vue.config.js
+++ b/launcher/vue.config.js
@@ -35,10 +35,8 @@ module.exports = {
           hardenedRuntime: isSigned,
           ...(isSigned
             ? {
-                entitlements:
-                  "./node_modules/@sapien99/vue-cli-plugin-electron-builder-notarize/entitlements.mac.inherit.plist",
-                entitlementsInherit:
-                  "./node_modules/@sapien99/vue-cli-plugin-electron-builder-notarize/entitlements.mac.inherit.plist",
+                entitlements: "./node_modules/@sapien99/vue-cli-plugin-electron-builder-notarize/entitlements.mac.inherit.plist",
+                entitlementsInherit: "./node_modules/@sapien99/vue-cli-plugin-electron-builder-notarize/entitlements.mac.inherit.plist",
               }
             : {}),
           gatekeeperAssess: false,


### PR DESCRIPTION
## FIX: workflow build

Fixes the `--universal` macOS build, which was failing with:

> Expected all non-binary files to have identical SHAs when creating a universal build but "Contents/Frameworks/Electron Framework.framework/Versions/A/_CodeSignature/CodeResources" did not

### Background
The previous commit added an `afterPack` hook to ad-hoc re-sign unsigned macOS builds for macOS 26+ Team ID compatibility. However, `afterPack` fires **once per arch** on the temporary per-arch outputs *before* `@electron/universal` merges them. Re-signing those temps produces different `CodeResources` files between x64 and arm64, causing the universal merge to fail.

### Changes

**`launcher/afterPackMac.js` → `launcher/afterSignMac.js`** (renamed)
- Hook function renamed `afterPackMac` → `afterSignMac`, log prefixes updated to match.
- Added a comment explaining why this must run as `afterSign` rather than `afterPack`: `afterSign` fires once on the final merged universal `.app`, after the merge succeeds.

**`launcher/vue.config.js`**
- Replaced the separate `afterSign` (notarize) and `afterPack` (re-sign) entries with a single conditional `afterSign` entry:
  - `shouldNotarize` → notarize plugin (signed + notarized builds).
  - `!isSigned` → `./afterSignMac.js` (unsigned builds).
  - Otherwise → no hook.
- Since both hooks now use the same `afterSign` slot, they're mutually exclusive by design (you'd never need both at once).

### Result
- Unsigned `--universal` builds: re-sign now runs on the merged universal `.app` instead of the per-arch temps, so the merge succeeds and the resulting app launches on macOS 14.4+ / 26+.
- Signed/notarized builds: behavior unchanged.