### PR TITLE
ADD: Ubuntu 26.04 Support

### DIFF
--- a/.github/workflows/code_quality_check.yml
+++ b/.github/workflows/code_quality_check.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   prettier:
     name: Prettier
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4

--- a/.github/workflows/code_quality_check.yml
+++ b/.github/workflows/code_quality_check.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   prettier:
     name: Prettier
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   ESLint-test:
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   ESLint-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4

--- a/.github/workflows/test-integration-alt.yml
+++ b/.github/workflows/test-integration-alt.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   Validator-Import-test:
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-latest
     name: Validator Import Tests
     needs:
       - Other-Integration-test
@@ -24,7 +24,7 @@ jobs:
           IS_DEV: "true"
 
   Execution-Client-test:
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-latest
     name: Execution Client Tests
     needs:
       - Other-Integration-test
@@ -42,7 +42,7 @@ jobs:
           IS_DEV: "true"
 
   Other-Integration-test:
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-latest
     name: Other Integration Tests
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/test-integration-alt.yml
+++ b/.github/workflows/test-integration-alt.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   Validator-Import-test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     name: Validator Import Tests
     needs:
       - Other-Integration-test
@@ -24,7 +24,7 @@ jobs:
           IS_DEV: "true"
 
   Execution-Client-test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     name: Execution Client Tests
     needs:
       - Other-Integration-test
@@ -42,7 +42,7 @@ jobs:
           IS_DEV: "true"
 
   Other-Integration-test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     name: Other Integration Tests
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   setup:
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-latest
     outputs:
       importTests: ${{ steps.get-import-tests.outputs.tests }}
       ELTests: ${{ steps.get-EL-tests.outputs.tests }}
@@ -34,7 +34,7 @@ jobs:
         working-directory: ./launcher
 
   Validator-Import-test:
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-latest
     name: test ${{ matrix.test.name }}
     needs:
       - setup
@@ -57,7 +57,7 @@ jobs:
           IS_DEV: "true"
 
   Execution-Client-test:
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-latest
     name: test ${{ matrix.test.name }}
     needs:
       - setup
@@ -79,7 +79,7 @@ jobs:
           IS_DEV: "true"
 
   Other-Integration-test:
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-latest
     name: test ${{ matrix.test.name }}
     needs:
       - setup
@@ -100,7 +100,7 @@ jobs:
           IS_DEV: "true"
 
   Cleanup:
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-latest
     name: Cleanup
     needs:
       - Validator-Import-test

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   setup:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     outputs:
       importTests: ${{ steps.get-import-tests.outputs.tests }}
       ELTests: ${{ steps.get-EL-tests.outputs.tests }}
@@ -34,7 +34,7 @@ jobs:
         working-directory: ./launcher
 
   Validator-Import-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     name: test ${{ matrix.test.name }}
     needs:
       - setup
@@ -57,7 +57,7 @@ jobs:
           IS_DEV: "true"
 
   Execution-Client-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     name: test ${{ matrix.test.name }}
     needs:
       - setup
@@ -79,7 +79,7 @@ jobs:
           IS_DEV: "true"
 
   Other-Integration-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     name: test ${{ matrix.test.name }}
     needs:
       - setup
@@ -100,7 +100,7 @@ jobs:
           IS_DEV: "true"
 
   Cleanup:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     name: Cleanup
     needs:
       - Validator-Import-test

--- a/.github/workflows/test-jest.yml
+++ b/.github/workflows/test-jest.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   jest-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4

--- a/.github/workflows/test-jest.yml
+++ b/.github/workflows/test-jest.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   jest-test:
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4

--- a/.github/workflows/test-molecule.yml
+++ b/.github/workflows/test-molecule.yml
@@ -16,7 +16,7 @@ jobs:
           ]
       fail-fast: false
     concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python
@@ -75,7 +75,7 @@ jobs:
           ]
       fail-fast: false
     concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python
@@ -130,7 +130,7 @@ jobs:
   #       tests: [{ role: "switch-repos", test: "default" }]
   #     fail-fast: false
   #   concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
-  #   runs-on: ubuntu-24.04
+  #   runs-on: ubuntu-26.04
   #   steps:
   #     - uses: actions/checkout@v5
   #     - name: Set up Python
@@ -185,7 +185,7 @@ jobs:
   #       tests: [{ role: "update-package", test: "default" }]
   #     fail-fast: false
   #   concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
-  #   runs-on: ubuntu-24.04
+  #   runs-on: ubuntu-26.04
   #   steps:
   #     - uses: actions/checkout@v5
   #     - name: Set up Python
@@ -240,7 +240,7 @@ jobs:
         tests: [{ role: "restart-services", test: "default" }]
       fail-fast: false
     concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python
@@ -298,7 +298,7 @@ jobs:
   #       ]
   #     fail-fast: false
   #   concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
-  #   runs-on: ubuntu-24.04
+  #   runs-on: ubuntu-26.04
   #   steps:
   #     - uses: actions/checkout@v5
   #     - name: Set up Python
@@ -353,7 +353,7 @@ jobs:
         tests: [{ role: "setup", test: "default" }]
       fail-fast: false
     concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python
@@ -460,7 +460,7 @@ jobs:
           ]
       fail-fast: false
     concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python
@@ -517,7 +517,7 @@ jobs:
         tests: [{ role: "ssv-key-generator", test: "default" }]
       fail-fast: false
     concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python
@@ -578,7 +578,7 @@ jobs:
           ]
       fail-fast: false
     concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python
@@ -640,7 +640,7 @@ jobs:
           ]
       fail-fast: false
     concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python

--- a/.github/workflows/test-molecule.yml
+++ b/.github/workflows/test-molecule.yml
@@ -16,7 +16,7 @@ jobs:
           ]
       fail-fast: false
     concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python
@@ -75,7 +75,7 @@ jobs:
           ]
       fail-fast: false
     concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python
@@ -130,7 +130,7 @@ jobs:
   #       tests: [{ role: "switch-repos", test: "default" }]
   #     fail-fast: false
   #   concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
-  #   runs-on: ubuntu-26.04
+  #   runs-on: ubuntu-latest
   #   steps:
   #     - uses: actions/checkout@v5
   #     - name: Set up Python
@@ -185,7 +185,7 @@ jobs:
   #       tests: [{ role: "update-package", test: "default" }]
   #     fail-fast: false
   #   concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
-  #   runs-on: ubuntu-26.04
+  #   runs-on: ubuntu-latest
   #   steps:
   #     - uses: actions/checkout@v5
   #     - name: Set up Python
@@ -240,7 +240,7 @@ jobs:
         tests: [{ role: "restart-services", test: "default" }]
       fail-fast: false
     concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python
@@ -298,7 +298,7 @@ jobs:
   #       ]
   #     fail-fast: false
   #   concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
-  #   runs-on: ubuntu-26.04
+  #   runs-on: ubuntu-latest
   #   steps:
   #     - uses: actions/checkout@v5
   #     - name: Set up Python
@@ -353,7 +353,7 @@ jobs:
         tests: [{ role: "setup", test: "default" }]
       fail-fast: false
     concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python
@@ -460,7 +460,7 @@ jobs:
           ]
       fail-fast: false
     concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python
@@ -517,7 +517,7 @@ jobs:
         tests: [{ role: "ssv-key-generator", test: "default" }]
       fail-fast: false
     concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python
@@ -578,7 +578,7 @@ jobs:
           ]
       fail-fast: false
     concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python
@@ -640,7 +640,7 @@ jobs:
           ]
       fail-fast: false
     concurrency: molecule-test-${{ matrix.tests.role }}-${{ matrix.tests.test }}
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python

--- a/controls/roles/configure-firewall/molecule/default/molecule.yml
+++ b/controls/roles/configure-firewall/molecule/default/molecule.yml
@@ -11,7 +11,7 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
       - /lib/modules:/lib/modules:ro
-  - name: "role-configure-updates-ubuntu-22.04"
+  - name: "role-configure-updates-ubuntu-26.04"
     image: geerlingguy/docker-ubuntu2204-ansible
     privileged: true
     pre_build_image: true

--- a/controls/roles/configure-updates/molecule/default/molecule.yml
+++ b/controls/roles/configure-updates/molecule/default/molecule.yml
@@ -4,8 +4,8 @@
 driver:
   name: docker
 platforms:
-  - name: "configure-updates--default--ubuntu-24.04"
-    image: ubuntu:noble
+  - name: "configure-updates--default--ubuntu-26.04"
+    image: ubuntu:resolute
   # - name: "configure-updates--default--centos-8"
   #   image: geerlingguy/docker-centos8-ansible
 provisioner:

--- a/controls/roles/configure-updates/molecule/no-unattended-updates/molecule.yml
+++ b/controls/roles/configure-updates/molecule/no-unattended-updates/molecule.yml
@@ -4,10 +4,8 @@
 driver:
   name: docker
 platforms:
-  - name: "configure-updates--default--ubuntu-24.04"
-    image: ubuntu:noble
-  - name: "configure-updates--default--ubuntu-24.04"
-    image: ubuntu:noble
+  - name: "configure-updates--default--ubuntu-26.04"
+    image: ubuntu:resolute
   # - name: "configure-updates--default--centos-8"
   #   image: geerlingguy/docker-centos8-ansible
 provisioner:

--- a/controls/roles/initiate-devnet-genesis/molecule/default/molecule.yml
+++ b/controls/roles/initiate-devnet-genesis/molecule/default/molecule.yml
@@ -4,9 +4,9 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "initiate-devnet-genesis--default--ubuntu-24.04"
+  - name: "initiate-devnet-genesis--default--ubuntu-26.04"
     server_type: cpx11
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 provisioner:
   name: ansible

--- a/controls/roles/manage-service/molecule/besu-lighthouse/molecule.yml
+++ b/controls/roles/manage-service/molecule/besu-lighthouse/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--besu-lighthouse--ubuntu-24.04"
+  - name: "manage-service--besu-lighthouse--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--besu-lighthouse--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/besu-lodestar/molecule.yml
+++ b/controls/roles/manage-service/molecule/besu-lodestar/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--mevboost-besu-lodestar--ubuntu-24.04"
+  - name: "manage-service--mevboost-besu-lodestar--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--mevboost-besu-lodestar--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/besu-nimbus/molecule.yml
+++ b/controls/roles/manage-service/molecule/besu-nimbus/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--besu-nimbus--ubuntu-24.04"
+  - name: "manage-service--besu-nimbus--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--besu-nimbus--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/besu-prysm/molecule.yml
+++ b/controls/roles/manage-service/molecule/besu-prysm/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--besu-prysm--ubuntu-24.04"
+  - name: "manage-service--besu-prysm--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--besu-prysm--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/besu-teku/molecule.yml
+++ b/controls/roles/manage-service/molecule/besu-teku/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--besu-teku--ubuntu-24.04"
+  - name: "manage-service--besu-teku--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--besu-teku--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/erigon-lighthouse/molecule.yml
+++ b/controls/roles/manage-service/molecule/erigon-lighthouse/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--erigon-lighthouse--ubuntu-24.04"
+  - name: "manage-service--erigon-lighthouse--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--erigon-lighthouse--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/erigon-lodestar/molecule.yml
+++ b/controls/roles/manage-service/molecule/erigon-lodestar/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--erigon-lodestar--ubuntu-24.04"
+  - name: "manage-service--erigon-lodestar--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--erigon-lodestar--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/erigon-prysm/molecule.yml
+++ b/controls/roles/manage-service/molecule/erigon-prysm/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--erigon-prysm--ubuntu-24.04"
+  - name: "manage-service--erigon-prysm--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--erigon-prysm--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/geth-lighthouse/molecule.yml
+++ b/controls/roles/manage-service/molecule/geth-lighthouse/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--geth-lighthouse--ubuntu-24.04"
+  - name: "manage-service--geth-lighthouse--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--geth-lighthouse--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/geth-nimbus/molecule.yml
+++ b/controls/roles/manage-service/molecule/geth-nimbus/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--geth-nimbus--ubuntu-24.04"
+  - name: "manage-service--geth-nimbus--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--geth-nimbus--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/geth-prysm/molecule.yml
+++ b/controls/roles/manage-service/molecule/geth-prysm/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--geth-prysm--ubuntu-24.04"
+  - name: "manage-service--geth-prysm--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--geth-prysm--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/geth-teku/molecule.yml
+++ b/controls/roles/manage-service/molecule/geth-teku/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--geth-teku--ubuntu-24.04"
+  - name: "manage-service--geth-teku--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--geth-teku--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/mevboost-besu-lighthouse/molecule.yml
+++ b/controls/roles/manage-service/molecule/mevboost-besu-lighthouse/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--mevboost-besu-lighthouse--ubuntu-24.04"
+  - name: "manage-service--mevboost-besu-lighthouse--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--mevboost-besu-lighthouse--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/mevboost-besu-nimbus/molecule.yml
+++ b/controls/roles/manage-service/molecule/mevboost-besu-nimbus/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--mevboost-besu-nimbus--ubuntu-24.04"
+  - name: "manage-service--mevboost-besu-nimbus--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--mevboost-besu-nimbus--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/mevboost-besu-prysm/molecule.yml
+++ b/controls/roles/manage-service/molecule/mevboost-besu-prysm/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--mevboost-besu-prysm--ubuntu-24.04"
+  - name: "manage-service--mevboost-besu-prysm--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--mevboost-besu-prysm--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/mevboost-besu-teku/molecule.yml
+++ b/controls/roles/manage-service/molecule/mevboost-besu-teku/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--mevboost-besu-teku--ubuntu-24.04"
+  - name: "manage-service--mevboost-besu-teku--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--mevboost-besu-teku--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/mevboost-erigon-lodestar/molecule.yml
+++ b/controls/roles/manage-service/molecule/mevboost-erigon-lodestar/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--mevboost-erigon-lodestar--ubuntu-24.04"
+  - name: "manage-service--mevboost-erigon-lodestar--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--mevboost-erigon-lodestar--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/mevboost-geth-lighthouse/molecule.yml
+++ b/controls/roles/manage-service/molecule/mevboost-geth-lighthouse/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--mevboost-geth-lighthouse--ubuntu-24.04"
+  - name: "manage-service--mevboost-geth-lighthouse--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--mevboost-geth-lighthouse--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/mevboost-geth-nimbus/molecule.yml
+++ b/controls/roles/manage-service/molecule/mevboost-geth-nimbus/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--mevboost-geth-nimbus--ubuntu-24.04"
+  - name: "manage-service--mevboost-geth-nimbus--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--mevboost-geth-nimbus--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/mevboost-geth-prysm/molecule.yml
+++ b/controls/roles/manage-service/molecule/mevboost-geth-prysm/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--mevboost-geth-prysm--ubuntu-24.04"
+  - name: "manage-service--mevboost-geth-prysm--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--mevboost-geth-prysm--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/mevboost-geth-teku/molecule.yml
+++ b/controls/roles/manage-service/molecule/mevboost-geth-teku/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--mevboost-geth-teku--ubuntu-24.04"
+  - name: "manage-service--mevboost-geth-teku--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--mevboost-geth-teku--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/mevboost-nethermind-lighthouse/molecule.yml
+++ b/controls/roles/manage-service/molecule/mevboost-nethermind-lighthouse/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--mevboost-nethermind-lighthouse--ubuntu-24.04"
+  - name: "manage-service--mevboost-nethermind-lighthouse--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--mevboost-nethermind-lighthouse--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/mevboost-nethermind-nimbus/molecule.yml
+++ b/controls/roles/manage-service/molecule/mevboost-nethermind-nimbus/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--mevboost-nethermind-nimbus--ubuntu-24.04"
+  - name: "manage-service--mevboost-nethermind-nimbus--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--mevboost-nethermind-nimbus--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/mevboost-nethermind-prysm/molecule.yml
+++ b/controls/roles/manage-service/molecule/mevboost-nethermind-prysm/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--mevboost-nethermind-prysm--ubuntu-24.04"
+  - name: "manage-service--mevboost-nethermind-prysm--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--mevboost-nethermind-prysm--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/mevboost-nethermind-teku/molecule.yml
+++ b/controls/roles/manage-service/molecule/mevboost-nethermind-teku/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--mevboost-nethermind-teku--ubuntu-24.04"
+  - name: "manage-service--mevboost-nethermind-teku--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--mevboost-nethermind-teku--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/monitor-besu/molecule.yml
+++ b/controls/roles/manage-service/molecule/monitor-besu/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--monitor-besu--ubuntu-24.04"
+  - name: "manage-service--monitor-besu--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 provisioner:
   name: ansible

--- a/controls/roles/manage-service/molecule/monitor-erigon/molecule.yml
+++ b/controls/roles/manage-service/molecule/monitor-erigon/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--monitor-erigon--ubuntu-24.04"
+  - name: "manage-service--monitor-erigon--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 provisioner:
   name: ansible

--- a/controls/roles/manage-service/molecule/monitor-geth/molecule.yml
+++ b/controls/roles/manage-service/molecule/monitor-geth/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--monitor-geth--ubuntu-24.04"
+  - name: "manage-service--monitor-geth--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 provisioner:
   name: ansible

--- a/controls/roles/manage-service/molecule/monitor-lighthouse/molecule.yml
+++ b/controls/roles/manage-service/molecule/monitor-lighthouse/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--monitor-lighthouse--ubuntu-24.04"
+  - name: "manage-service--monitor-lighthouse--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--monitor-lighthouse--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/monitor-lodestar/molecule.yml
+++ b/controls/roles/manage-service/molecule/monitor-lodestar/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--monitor-lodestar--ubuntu-24.04"
+  - name: "manage-service--monitor-lodestar--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--monitor-lodestar--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/monitor-nethermind/molecule.yml
+++ b/controls/roles/manage-service/molecule/monitor-nethermind/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--monitor-nethermind--ubuntu-24.04"
+  - name: "manage-service--monitor-nethermind--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 provisioner:
   name: ansible

--- a/controls/roles/manage-service/molecule/monitor-nimbus/molecule.yml
+++ b/controls/roles/manage-service/molecule/monitor-nimbus/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--monitor-nimbus--ubuntu-24.04"
+  - name: "manage-service--monitor-nimbus--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--monitor-nimbus--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/monitor-prysm/molecule.yml
+++ b/controls/roles/manage-service/molecule/monitor-prysm/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--monitor-prysm--ubuntu-24.04"
+  - name: "manage-service--monitor-prysm--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--monitor-prysm--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/monitor-ssvnetwork/molecule.yml
+++ b/controls/roles/manage-service/molecule/monitor-ssvnetwork/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--monitor-ssvnet--ubuntu-24.04"
+  - name: "manage-service--monitor-ssvnet--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 provisioner:
   name: ansible

--- a/controls/roles/manage-service/molecule/monitor-teku/molecule.yml
+++ b/controls/roles/manage-service/molecule/monitor-teku/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--monitor-teku--ubuntu-24.04"
+  - name: "manage-service--monitor-teku--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--monitor-teku--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/nethermind-lighthouse/molecule.yml
+++ b/controls/roles/manage-service/molecule/nethermind-lighthouse/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--nethermind-lighthouse--ubuntu-24.04"
+  - name: "manage-service--nethermind-lighthouse--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--nethermind-lighthouse--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/nethermind-nimbus/molecule.yml
+++ b/controls/roles/manage-service/molecule/nethermind-nimbus/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--nethermind-nimbus--ubuntu-24.04"
+  - name: "manage-service--nethermind-nimbus--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--nethermind-nimbus--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/nethermind-prysm/molecule.yml
+++ b/controls/roles/manage-service/molecule/nethermind-prysm/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--nethermind-teku--ubuntu-24.04"
+  - name: "manage-service--nethermind-teku--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--nethermind-teku--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/nethermind-teku-gnosis/molecule.yml
+++ b/controls/roles/manage-service/molecule/nethermind-teku-gnosis/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--nethermind-teku-gnosis--ubuntu-24.04"
+  - name: "manage-service--nethermind-teku-gnosis--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--nethermind-teku-gnosis--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/nethermind-teku/molecule.yml
+++ b/controls/roles/manage-service/molecule/nethermind-teku/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--nethermind-teku--ubuntu-24.04"
+  - name: "manage-service--nethermind-teku--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--nethermind-teku--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/nimbus-checkpoint-sync/molecule.yml
+++ b/controls/roles/manage-service/molecule/nimbus-checkpoint-sync/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--nimbus-checkpointsync--ubuntu-24.04"
+  - name: "manage-service--nimbus-checkpointsync--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx21
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "nimbus-checkpointsync--default--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/ssv-lighthouse/molecule.yml
+++ b/controls/roles/manage-service/molecule/ssv-lighthouse/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--ssv-lighthouse--ubuntu-24.04"
+  - name: "manage-service--ssv-lighthouse--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--ssv-lighthouse--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/ssv-lodestar/molecule.yml
+++ b/controls/roles/manage-service/molecule/ssv-lodestar/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--ssv-lodestar--ubuntu-24.04"
+  - name: "manage-service--ssv-lodestar--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--ssv-lodestar--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/ssv-nimbus/molecule.yml
+++ b/controls/roles/manage-service/molecule/ssv-nimbus/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--ssv-nimbus--ubuntu-24.04"
+  - name: "manage-service--ssv-nimbus--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--ssv-nimbus--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/ssv-prysm/molecule.yml
+++ b/controls/roles/manage-service/molecule/ssv-prysm/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--ssv-prysm--ubuntu-24.04"
+  - name: "manage-service--ssv-prysm--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--ssv-prysm--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/ssv-teku/molecule.yml
+++ b/controls/roles/manage-service/molecule/ssv-teku/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--ssv-teku--ubuntu-24.04"
+  - name: "manage-service--ssv-teku--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--ssv-teku--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/start-multiple/molecule.yml
+++ b/controls/roles/manage-service/molecule/start-multiple/molecule.yml
@@ -4,9 +4,9 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--start-multiple--ubuntu-24.04"
+  - name: "manage-service--start-multiple--ubuntu-26.04"
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--start-multiple--centos-stream-8"
 #    server_type: cpx31

--- a/controls/roles/manage-service/molecule/start-stop/molecule.yml
+++ b/controls/roles/manage-service/molecule/start-stop/molecule.yml
@@ -4,9 +4,9 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--start-stop--ubuntu-24.04"
+  - name: "manage-service--start-stop--ubuntu-26.04"
     server_type: cpx21
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
   # - name: "role-manage-service-centos-7"
   #   server_type: cpx11

--- a/controls/roles/manage-service/molecule/start/molecule.yml
+++ b/controls/roles/manage-service/molecule/start/molecule.yml
@@ -4,9 +4,9 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--start--ubuntu-24.04"
+  - name: "manage-service--start--ubuntu-26.04"
     server_type: cpx21
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
   # - name: "role-manage-service-centos-7"
   #   server_type: cpx11

--- a/controls/roles/manage-service/molecule/teku-geth/molecule.yml
+++ b/controls/roles/manage-service/molecule/teku-geth/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--teku-geth--ubuntu-24.04"
+  - name: "manage-service--teku-geth--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "manage-service--teku-geth--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/manage-service/molecule/write-start/molecule.yml
+++ b/controls/roles/manage-service/molecule/write-start/molecule.yml
@@ -4,11 +4,11 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "manage-service--write-start--ubuntu-24.04"
+  - name: "manage-service--write-start--ubuntu-26.04"
     server_type: cpx11
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
-  # - name: "role-manage--write-start--ubuntu-24.04"
+  # - name: "role-manage--write-start--ubuntu-26.04"
   #   server_type: cpx11
   #   image: centos-7
 provisioner:

--- a/controls/roles/prune-geth/molecule/default/molecule.yml
+++ b/controls/roles/prune-geth/molecule/default/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "prune-geth--default--ubuntu-24.04"
+  - name: "prune-geth--default--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx21
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "prune-geth--default--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/restart-services/molecule/default/molecule.yml
+++ b/controls/roles/restart-services/molecule/default/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "restart-services--default--ubuntu-24.04"
+  - name: "restart-services--default--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 provisioner:
   name: ansible

--- a/controls/roles/setup/molecule/default/molecule.yml
+++ b/controls/roles/setup/molecule/default/molecule.yml
@@ -4,9 +4,9 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "setup--default--ubuntu-24.04"
+  - name: "setup--default--ubuntu-26.04"
     server_type: cpx11
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "setup--default--centos-stream-8"
 #    server_type: cpx11

--- a/controls/roles/setup/tasks/docker-ubuntu-2604.yaml
+++ b/controls/roles/setup/tasks/docker-ubuntu-2604.yaml
@@ -1,0 +1,50 @@
+---
+- name: Remove conflicting docker packages
+  apt:
+    name:
+      - docker-engine
+      - docker.io
+      - docker-registry
+    state: absent
+
+- name: Install required system packages
+  apt:
+    name:
+      - apt-transport-https
+      - ca-certificates
+      - curl
+      - software-properties-common
+      - python3-pip
+      - python3-docker
+      - virtualenv
+      - python3-setuptools
+      - gnupg2
+      - pass
+      - sysstat
+      - python3-jmespath
+
+- name: Create apt keyrings directory
+  file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+
+- name: Add Docker GPG key
+  get_url:
+    url: https://download.docker.com/linux/ubuntu/gpg
+    dest: /etc/apt/keyrings/docker.asc
+    mode: '0644'
+    force: false
+
+- name: Add Docker Repository
+  apt_repository:
+    repo: "deb [arch={{ 'amd64' if ansible_architecture == 'x86_64' else ansible_architecture }} signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu {{ ansible_facts['distribution_release'] }} stable"
+    filename: docker
+    state: present
+
+- name: Update apt and install docker-ce
+  apt:
+    update_cache: yes
+    name:
+      - docker-ce
+# EOF

--- a/controls/roles/setup/tasks/docker.yml
+++ b/controls/roles/setup/tasks/docker.yml
@@ -3,9 +3,13 @@
   include_tasks: docker-centos.yaml
   when: ansible_facts['distribution'] == "CentOS"
 
-- name: Docker on Ubuntu
+- name: Docker on Ubuntu (< 26.04)
   include_tasks: docker-ubuntu.yaml
-  when: ansible_facts['distribution'] == 'Debian' or ansible_facts['distribution'] == 'Ubuntu'
+  when: (ansible_facts['distribution'] == 'Debian' or ansible_facts['distribution'] == 'Ubuntu') and ansible_facts['distribution_major_version'] | int < 26
+
+- name: Docker on Ubuntu (>= 26.04)
+  include_tasks: docker-ubuntu-2604.yaml
+  when: ansible_facts['distribution'] == 'Ubuntu' and ansible_facts['distribution_major_version'] | int >= 26
 
 - name: Enable service docker
   systemd:

--- a/controls/roles/ssv-key-generator/molecule/default/molecule.yml
+++ b/controls/roles/ssv-key-generator/molecule/default/molecule.yml
@@ -4,10 +4,10 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "ssv-key-generator--default--ubuntu-24.04"
+  - name: "ssv-key-generator--default--ubuntu-26.04"
     hostname: ubuntu
     server_type: cpx21
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "ssv-key-generator--default--centos-stream-8"
 #    hostname: "centos"

--- a/controls/roles/switch-repos/molecule/default/molecule.yml
+++ b/controls/roles/switch-repos/molecule/default/molecule.yml
@@ -4,9 +4,9 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "switch-repos--default--ubuntu-24.04"
+  - name: "switch-repos--default--ubuntu-26.04"
     server_type: cpx11
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 provisioner:
   name: ansible

--- a/controls/roles/update-changes/molecule/242/molecule.yml
+++ b/controls/roles/update-changes/molecule/242/molecule.yml
@@ -4,8 +4,8 @@
 driver:
   name: docker
 platforms:
-  - name: "update-changes--2.4.2--ubuntu-24.04"
-    image: ubuntu:noble
+  - name: "update-changes--2.4.2--ubuntu-26.04"
+    image: ubuntu:resolute
   # - name: "configure-updates--default--centos-8"
   #   image: geerlingguy/docker-centos8-ansible
 provisioner:

--- a/controls/roles/update-changes/molecule/243/molecule.yml
+++ b/controls/roles/update-changes/molecule/243/molecule.yml
@@ -4,9 +4,9 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "update-changes--2.4.3--ubuntu-24.04"
+  - name: "update-changes--2.4.3--ubuntu-26.04"
     server_type: cpx11
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 provisioner:
   name: ansible

--- a/controls/roles/update-changes/molecule/244/molecule.yml
+++ b/controls/roles/update-changes/molecule/244/molecule.yml
@@ -4,9 +4,9 @@
 driver:
   name: docker
 platforms:
-  - name: "update-changes--2.4.4--ubuntu-24.04"
-    image: ubuntu:noble
-  # - name: "update-changes--2.4.4--ubuntu-24.04"
+  - name: "update-changes--2.4.4--ubuntu-26.04"
+    image: ubuntu:resolute
+  # - name: "update-changes--2.4.4--ubuntu-26.04"
   #   image: geerlingguy/docker-centos8-ansible
 provisioner:
   name: ansible

--- a/controls/roles/update-changes/molecule/245/molecule.yml
+++ b/controls/roles/update-changes/molecule/245/molecule.yml
@@ -4,8 +4,8 @@
 driver:
   name: docker
 platforms:
-  - name: "update-changes--2.4.5--ubuntu-24.04"
-    image: ubuntu:noble
+  - name: "update-changes--2.4.5--ubuntu-26.04"
+    image: ubuntu:resolute
   # - name: "configure-updates--default--centos-8"
   #   image: geerlingguy/docker-centos8-ansible
 provisioner:

--- a/controls/roles/update-changes/molecule/246/molecule.yml
+++ b/controls/roles/update-changes/molecule/246/molecule.yml
@@ -4,8 +4,8 @@
 driver:
   name: docker
 platforms:
-  - name: "update-changes--2.4.6--ubuntu-24.04"
-    image: ubuntu:noble
+  - name: "update-changes--2.4.6--ubuntu-26.04"
+    image: ubuntu:resolute
   # - name: "configure-updates--default--centos-8"
   #   image: geerlingguy/docker-centos8-ansible
 provisioner:

--- a/controls/roles/update-changes/molecule/247/molecule.yml
+++ b/controls/roles/update-changes/molecule/247/molecule.yml
@@ -4,8 +4,8 @@
 driver:
   name: docker
 platforms:
-  - name: "update-changes--2.4.7--ubuntu-24.04"
-    image: ubuntu:noble
+  - name: "update-changes--2.4.7--ubuntu-26.04"
+    image: ubuntu:resolute
   # - name: "configure-updates--default--centos-8"
   #   image: geerlingguy/docker-centos8-ansible
 provisioner:

--- a/controls/roles/update-os/molecule/default/molecule.yml
+++ b/controls/roles/update-os/molecule/default/molecule.yml
@@ -4,9 +4,9 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "update-os--default--ubuntu-24.04"
+  - name: "update-os--default--ubuntu-26.04"
     server_type: cpx11
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 provisioner:
   name: ansible

--- a/controls/roles/update-os/molecule/run-stereum-service-update/molecule.yml
+++ b/controls/roles/update-os/molecule/run-stereum-service-update/molecule.yml
@@ -4,9 +4,9 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "update-os--run-stereum-service-update--ubuntu-24.04"
+  - name: "update-os--run-stereum-service-update--ubuntu-26.04"
     server_type: cpx11
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 provisioner:
   name: ansible

--- a/controls/roles/update-package/molecule/default/molecule.yml
+++ b/controls/roles/update-package/molecule/default/molecule.yml
@@ -4,9 +4,9 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "update-package--default--ubuntu-24.04"
+  - name: "update-package--default--ubuntu-26.04"
     server_type: cpx11
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 provisioner:
   name: ansible

--- a/controls/roles/update-services/molecule/default/molecule.yml
+++ b/controls/roles/update-services/molecule/default/molecule.yml
@@ -5,9 +5,9 @@ driver:
   name: molecule_hetznercloud
 platforms:
   # cpx31 for the storage requirements
-  - name: "update-services--default--ubuntu-24.04"
+  - name: "update-services--default--ubuntu-26.04"
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "update-services--default--centos-stream-8"
 #    server_type: cpx31

--- a/controls/roles/update-services/molecule/single-service/molecule.yml
+++ b/controls/roles/update-services/molecule/single-service/molecule.yml
@@ -5,9 +5,9 @@ driver:
   name: molecule_hetznercloud
 platforms:
   # cpx31 for the storage requirements
-  - name: "update-services--single-service--ubuntu-24.04"
+  - name: "update-services--single-service--ubuntu-26.04"
     server_type: cpx31
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "update-services--default--centos-stream-8"
 #    server_type: cpx31

--- a/controls/roles/update-stereum/molecule/default/molecule.yml
+++ b/controls/roles/update-stereum/molecule/default/molecule.yml
@@ -4,9 +4,9 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "update-stereum--default--ubuntu-24.04"
+  - name: "update-stereum--default--ubuntu-26.04"
     server_type: cpx11
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "update-stereum--default--centos-stream-8"
 #    server_type: cpx11

--- a/controls/roles/update-stereum/molecule/full/molecule.yml
+++ b/controls/roles/update-stereum/molecule/full/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: "update-stereum--full--ubuntu-2204"
     server_type: cpx21
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "update-stereum--default--centos-stream-8"
 #    server_type: cpx11

--- a/controls/roles/update-stereum/molecule/override/molecule.yml
+++ b/controls/roles/update-stereum/molecule/override/molecule.yml
@@ -4,9 +4,9 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "update-stereum--override--ubuntu-24.04"
+  - name: "update-stereum--override--ubuntu-26.04"
     server_type: cpx11
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 #  - name: "update-stereum--default--centos-stream-8"
 #    server_type: cpx11

--- a/controls/roles/upgrade-prep/molecule/default/molecule.yml
+++ b/controls/roles/upgrade-prep/molecule/default/molecule.yml
@@ -4,9 +4,9 @@ dependency:
 driver:
   name: molecule_hetznercloud
 platforms:
-  - name: "upgrade-prep--default--ubuntu-24.04"
+  - name: "upgrade-prep--default--ubuntu-26.04"
     server_type: cpx11
-    image: ubuntu-24.04
+    image: ubuntu-26.04
     location: hil
 provisioner:
   name: ansible

--- a/launcher/src/backend/NodeConnection.js
+++ b/launcher/src/backend/NodeConnection.js
@@ -166,14 +166,17 @@ export class NodeConnection {
         status: true,
       });
       let installPkgResult;
-      try {
-        installPkgResult = await this.sshService.exec(
-          "sudo -u root apt update &&\
+      const ubuntuMajorVersion = parseFloat(this.osv);
+      const needsAnsiblePpa = ubuntuMajorVersion < 26;
+      const installCmd = needsAnsiblePpa
+        ? "sudo -u root apt update &&\
           sudo -u root apt install -y software-properties-common &&\
           sudo -u root add-apt-repository --yes --update ppa:ansible/ansible &&\
-          sudo -u root apt install -y pip ansible tar gzip wget git",
-          false
-        );
+          sudo -u root apt install -y pip ansible tar gzip wget git"
+        : "sudo -u root apt update &&\
+          sudo -u root apt install -y pip ansible tar gzip wget git";
+      try {
+        installPkgResult = await this.sshService.exec(installCmd, false);
       } catch (err) {
         log.error(err);
         installPkgResult = { rc: 1, stderr: err };
@@ -350,6 +353,7 @@ export class NodeConnection {
       ansibleResult = await this.sshService.exec(
         "             ANSIBLE_LOAD_CALLBACK_PLUGINS=1\
                         ANSIBLE_STDOUT_CALLBACK=stereumjson\
+                        ANSIBLE_DEPRECATION_WARNINGS=false\
                         ANSIBLE_LOG_FOLDER=/tmp/" +
           playbookRunRef +
           "\

--- a/launcher/src/backend/tests/integration/BesuService.int.js
+++ b/launcher/src/backend/tests/integration/BesuService.int.js
@@ -11,11 +11,11 @@ jest.setTimeout(500000);
 
 test("besu installation", async () => {
   const testServer = new HetznerServer();
-  const keyResponse = await testServer.createSSHKey("Besu--integration-test--ubuntu-2204");
+  const keyResponse = await testServer.createSSHKey("Besu--integration-test--ubuntu-2604");
 
   const serverSettings = {
-    name: "Besu--integration-test--ubuntu-2204",
-    image: "ubuntu-22.04",
+    name: "Besu--integration-test--ubuntu-2604",
+    image: "ubuntu-26.04",
     server_type: "cpx21",
     start_after_create: true,
     ssh_keys: [keyResponse.ssh_key.id],

--- a/launcher/src/backend/tests/integration/ErigonOptimismService.int.js
+++ b/launcher/src/backend/tests/integration/ErigonOptimismService.int.js
@@ -11,11 +11,11 @@ jest.setTimeout(1200000);
 
 test("op-erigon installation", async () => {
   const testServer = new HetznerServer();
-  const keyResponse = await testServer.createSSHKey("Optimism-Erigon--integration-test--ubuntu-2204");
+  const keyResponse = await testServer.createSSHKey("Optimism-Erigon--integration-test--ubuntu-2604");
 
   const serverSettings = {
-    name: "Optimism-Erigon--integration-test--ubuntu-2204",
-    image: "ubuntu-22.04",
+    name: "Optimism-Erigon--integration-test--ubuntu-2604",
+    image: "ubuntu-26.04",
     server_type: "cpx21",
     start_after_create: true,
     ssh_keys: [keyResponse.ssh_key.id],

--- a/launcher/src/backend/tests/integration/ErigonService.int.js
+++ b/launcher/src/backend/tests/integration/ErigonService.int.js
@@ -11,11 +11,11 @@ jest.setTimeout(500000);
 
 test("erigon installation", async () => {
   const testServer = new HetznerServer();
-  const keyResponse = await testServer.createSSHKey("Erigon--integration-test--ubuntu-2204");
+  const keyResponse = await testServer.createSSHKey("Erigon--integration-test--ubuntu-2604");
 
   const serverSettings = {
-    name: "Erigon--integration-test--ubuntu-2204",
-    image: "ubuntu-22.04",
+    name: "Erigon--integration-test--ubuntu-2604",
+    image: "ubuntu-26.04",
     server_type: "cpx21",
     start_after_create: true,
     ssh_keys: [keyResponse.ssh_key.id],

--- a/launcher/src/backend/tests/integration/FlashbotsMevBoostService.int.js
+++ b/launcher/src/backend/tests/integration/FlashbotsMevBoostService.int.js
@@ -11,11 +11,11 @@ jest.setTimeout(600000);
 
 test("mevboost installation", async () => {
   const testServer = new HetznerServer();
-  const keyResponse = await testServer.createSSHKey("Mevboost--integration-test--ubuntu-2204");
+  const keyResponse = await testServer.createSSHKey("Mevboost--integration-test--ubuntu-2604");
 
   const serverSettings = {
-    name: "Mevboost--integration-test--ubuntu-2204",
-    image: "ubuntu-22.04",
+    name: "Mevboost--integration-test--ubuntu-2604",
+    image: "ubuntu-26.04",
     server_type: "cpx21",
     start_after_create: true,
     ssh_keys: [keyResponse.ssh_key.id],

--- a/launcher/src/backend/tests/integration/GethLayer2Service.int.js
+++ b/launcher/src/backend/tests/integration/GethLayer2Service.int.js
@@ -11,11 +11,11 @@ jest.setTimeout(500000);
 
 test("l2geth installation", async () => {
   const testServer = new HetznerServer();
-  const keyResponse = await testServer.createSSHKey("Layer2-Geth--integration-test--ubuntu-2204");
+  const keyResponse = await testServer.createSSHKey("Layer2-Geth--integration-test--ubuntu-2604");
 
   const serverSettings = {
-    name: "Layer2-Geth--integration-test--ubuntu-2204",
-    image: "ubuntu-22.04",
+    name: "Layer2-Geth--integration-test--ubuntu-2604",
+    image: "ubuntu-26.04",
     server_type: "cpx21",
     start_after_create: true,
     ssh_keys: [keyResponse.ssh_key.id],

--- a/launcher/src/backend/tests/integration/GethOptimismService.int.js
+++ b/launcher/src/backend/tests/integration/GethOptimismService.int.js
@@ -11,11 +11,11 @@ jest.setTimeout(500000);
 
 test("op-geth installation", async () => {
   const testServer = new HetznerServer();
-  const keyResponse = await testServer.createSSHKey("Optimism-Geth--integration-test--ubuntu-2204");
+  const keyResponse = await testServer.createSSHKey("Optimism-Geth--integration-test--ubuntu-2604");
 
   const serverSettings = {
-    name: "Optimism-Geth--integration-test--ubuntu-2204",
-    image: "ubuntu-22.04",
+    name: "Optimism-Geth--integration-test--ubuntu-2604",
+    image: "ubuntu-26.04",
     server_type: "cpx21",
     start_after_create: true,
     ssh_keys: [keyResponse.ssh_key.id],

--- a/launcher/src/backend/tests/integration/GethService.int.js
+++ b/launcher/src/backend/tests/integration/GethService.int.js
@@ -11,11 +11,11 @@ jest.setTimeout(600000);
 
 test("geth installation", async () => {
   const testServer = new HetznerServer();
-  const keyResponse = await testServer.createSSHKey("Geth--integration-test--ubuntu-2204");
+  const keyResponse = await testServer.createSSHKey("Geth--integration-test--ubuntu-2604");
 
   const serverSettings = {
-    name: "Geth--integration-test--ubuntu-2204",
-    image: "ubuntu-22.04",
+    name: "Geth--integration-test--ubuntu-2604",
+    image: "ubuntu-26.04",
     server_type: "cpx21",
     start_after_create: true,
     ssh_keys: [keyResponse.ssh_key.id],

--- a/launcher/src/backend/tests/integration/GrandineBeaconService.int.js
+++ b/launcher/src/backend/tests/integration/GrandineBeaconService.int.js
@@ -12,11 +12,11 @@ jest.setTimeout(1800000);
 
 test("grandine consensus client", async () => {
   const testServer = new HetznerServer();
-  const keyResponse = await testServer.createSSHKey("Grandine--integration-test--ubuntu-2204");
+  const keyResponse = await testServer.createSSHKey("Grandine--integration-test--ubuntu-2604");
 
   const serverSettings = {
-    name: "Grandine--integration-test--ubuntu-2204",
-    image: "ubuntu-22.04",
+    name: "Grandine--integration-test--ubuntu-2604",
+    image: "ubuntu-26.04",
     server_type: "cpx31",
     start_after_create: true,
     ssh_keys: [keyResponse.ssh_key.id],

--- a/launcher/src/backend/tests/integration/LighthouseBeaconService.int.js
+++ b/launcher/src/backend/tests/integration/LighthouseBeaconService.int.js
@@ -12,11 +12,11 @@ jest.setTimeout(1800000);
 
 test("lighthouse validator import", async () => {
   const testServer = new HetznerServer();
-  const keyResponse = await testServer.createSSHKey("Lighthouse--integration-test--ubuntu-2204");
+  const keyResponse = await testServer.createSSHKey("Lighthouse--integration-test--ubuntu-2604");
 
   const serverSettings = {
-    name: "Lighthouse--integration-test--ubuntu-2204",
-    image: "ubuntu-22.04",
+    name: "Lighthouse--integration-test--ubuntu-2604",
+    image: "ubuntu-26.04",
     server_type: "cpx31",
     start_after_create: true,
     ssh_keys: [keyResponse.ssh_key.id],

--- a/launcher/src/backend/tests/integration/LodestarBeaconService.int.js
+++ b/launcher/src/backend/tests/integration/LodestarBeaconService.int.js
@@ -13,11 +13,11 @@ jest.setTimeout(1800000);
 test("lodestar validator import", async () => {
   //create server
   const testServer = new HetznerServer();
-  const keyResponse = await testServer.createSSHKey("Lodestar--integration-test--ubuntu-2204");
+  const keyResponse = await testServer.createSSHKey("Lodestar--integration-test--ubuntu-2604");
 
   const serverSettings = {
-    name: "Lodestar--integration-test--ubuntu-2204",
-    image: "ubuntu-22.04",
+    name: "Lodestar--integration-test--ubuntu-2604",
+    image: "ubuntu-26.04",
     server_type: "cpx31",
     start_after_create: true,
     ssh_keys: [keyResponse.ssh_key.id],

--- a/launcher/src/backend/tests/integration/NethermindService.int.js
+++ b/launcher/src/backend/tests/integration/NethermindService.int.js
@@ -11,11 +11,11 @@ jest.setTimeout(500000);
 
 test("nethermind installationm", async () => {
   const testServer = new HetznerServer();
-  const keyResponse = await testServer.createSSHKey("Nethermind--integration-test--ubuntu-2204");
+  const keyResponse = await testServer.createSSHKey("Nethermind--integration-test--ubuntu-2604");
 
   const serverSettings = {
-    name: "Nethermind--integration-test--ubuntu-2204",
-    image: "ubuntu-22.04",
+    name: "Nethermind--integration-test--ubuntu-2604",
+    image: "ubuntu-26.04",
     server_type: "cpx21",
     start_after_create: true,
     ssh_keys: [keyResponse.ssh_key.id],

--- a/launcher/src/backend/tests/integration/NimbusBeaconService.int.js
+++ b/launcher/src/backend/tests/integration/NimbusBeaconService.int.js
@@ -13,11 +13,11 @@ jest.setTimeout(1800000);
 test("nimbus validator import", async () => {
   //create server
   const testServer = new HetznerServer();
-  const keyResponse = await testServer.createSSHKey("Nimbus--integration-test--ubuntu-2204");
+  const keyResponse = await testServer.createSSHKey("Nimbus--integration-test--ubuntu-2604");
 
   const serverSettings = {
-    name: "Nimbus--integration-test--ubuntu-2204",
-    image: "ubuntu-22.04",
+    name: "Nimbus--integration-test--ubuntu-2604",
+    image: "ubuntu-26.04",
     server_type: "cpx31",
     start_after_create: true,
     ssh_keys: [keyResponse.ssh_key.id],

--- a/launcher/src/backend/tests/integration/NodeConnection.int.js
+++ b/launcher/src/backend/tests/integration/NodeConnection.int.js
@@ -11,11 +11,11 @@ jest.setTimeout(500000);
 
 test("prepareStereumNode on ubuntu", async () => {
   const testServer = new HetznerServer();
-  const keyResponse = await testServer.createSSHKey("NodeConnection--integration-test--ubuntu-2204");
+  const keyResponse = await testServer.createSSHKey("NodeConnection--integration-test--ubuntu-2604");
 
   const serverSettings = {
-    name: "NodeConnection--integration-test--ubuntu-2204",
-    image: "ubuntu-22.04",
+    name: "NodeConnection--integration-test--ubuntu-2604",
+    image: "ubuntu-26.04",
     server_type: "cpx21",
     start_after_create: true,
     ssh_keys: [keyResponse.ssh_key.id],

--- a/launcher/src/backend/tests/integration/PrysmBeaconService.int.js
+++ b/launcher/src/backend/tests/integration/PrysmBeaconService.int.js
@@ -12,11 +12,11 @@ jest.setTimeout(1800000);
 
 test("prysm validator import", async () => {
   const testServer = new HetznerServer();
-  const keyResponse = await testServer.createSSHKey("Prysm--integration-test--ubuntu-2204");
+  const keyResponse = await testServer.createSSHKey("Prysm--integration-test--ubuntu-2604");
 
   const serverSettings = {
-    name: "Prysm--integration-test--ubuntu-2204",
-    image: "ubuntu-22.04",
+    name: "Prysm--integration-test--ubuntu-2604",
+    image: "ubuntu-26.04",
     server_type: "cpx31",
     start_after_create: true,
     ssh_keys: [keyResponse.ssh_key.id],

--- a/launcher/src/backend/tests/integration/RethOptimismService.int.js
+++ b/launcher/src/backend/tests/integration/RethOptimismService.int.js
@@ -11,11 +11,11 @@ jest.setTimeout(500000);
 
 test("op-reth installation", async () => {
   const testServer = new HetznerServer();
-  const keyResponse = await testServer.createSSHKey("Optimism-Reth--integration-test--ubuntu-2204");
+  const keyResponse = await testServer.createSSHKey("Optimism-Reth--integration-test--ubuntu-2604");
 
   const serverSettings = {
-    name: "Optimism-Reth--integration-test--ubuntu-2204",
-    image: "ubuntu-22.04",
+    name: "Optimism-Reth--integration-test--ubuntu-2604",
+    image: "ubuntu-26.04",
     server_type: "cpx21",
     start_after_create: true,
     ssh_keys: [keyResponse.ssh_key.id],

--- a/launcher/src/backend/tests/integration/RethService.int.js
+++ b/launcher/src/backend/tests/integration/RethService.int.js
@@ -11,11 +11,11 @@ jest.setTimeout(600000);
 
 test("reth installation", async () => {
   const testServer = new HetznerServer();
-  const keyResponse = await testServer.createSSHKey("Reth--integration-test--ubuntu-2204");
+  const keyResponse = await testServer.createSSHKey("Reth--integration-test--ubuntu-2604");
 
   const serverSettings = {
-    name: "Reth--integration-test--ubuntu-2204",
-    image: "ubuntu-22.04",
+    name: "Reth--integration-test--ubuntu-2604",
+    image: "ubuntu-26.04",
     server_type: "cpx21",
     start_after_create: true,
     ssh_keys: [keyResponse.ssh_key.id],

--- a/launcher/src/backend/tests/integration/TekuBeaconService.int.js
+++ b/launcher/src/backend/tests/integration/TekuBeaconService.int.js
@@ -12,11 +12,11 @@ jest.setTimeout(1800000);
 
 test("teku validator import", async () => {
   const testServer = new HetznerServer();
-  const keyResponse = await testServer.createSSHKey("Teku--integration-test--ubuntu-2204");
+  const keyResponse = await testServer.createSSHKey("Teku--integration-test--ubuntu-2604");
 
   const serverSettings = {
-    name: "Teku--integration-test--ubuntu-2204",
-    image: "ubuntu-22.04",
+    name: "Teku--integration-test--ubuntu-2604",
+    image: "ubuntu-26.04",
     server_type: "cpx31",
     start_after_create: true,
     ssh_keys: [keyResponse.ssh_key.id],

--- a/launcher/src/components/UI/welcome-page/components/WelcomeFooter.vue
+++ b/launcher/src/components/UI/welcome-page/components/WelcomeFooter.vue
@@ -42,7 +42,7 @@ const display = async (osResponse, suResponse) => {
   const suData = await suResponse;
   const osName = osData && osData.hasOwnProperty("name") && osData.name ? osData.name : "";
   const osVers = osData && osData.hasOwnProperty("version") && osData.version ? osData.version : "";
-  if (osName === "Ubuntu" && (osVers === "22.04" || osVers === "24.04")) {
+  if (osName === "Ubuntu" && (osVers === "22.04" || osVers === "24.04" || osVers === "26.04")) {
     message.value = osName.toUpperCase() + " " + osVers + " " + supportMessage;
     if (suData.rc) {
       // Description of return codes (suData.rc):
@@ -71,7 +71,7 @@ const display = async (osResponse, suResponse) => {
       isSupported.value = true;
     }
   } else {
-    message.value = "UNSUPPORTED OS. USE UBUNTU VERSION 22.04 OR 24.04.";
+    message.value = "UNSUPPORTED OS. USE UBUNTU VERSION 22.04, 24.04 OR 26.04.";
   }
   active.value = false;
 };


### PR DESCRIPTION
# Ubuntu 26.04 Support

Adds full Ubuntu 26.04 ("resolute") support across the stack.

## Changes

- **Package installation fix** (`NodeConnection.js`): Skip `ppa:ansible/ansible` on Ubuntu 26.04+ since the PPA isn't available — Ansible is installed from the default Ubuntu repos instead. Improved ansible playbook error reporting to include stdout alongside stderr.
- **Docker installation fix** (`docker-ubuntu-2604.yaml`, `docker.yml`): `apt-key` was removed in Ubuntu 26.04. Added a new `docker-ubuntu-2604.yaml` role that uses the modern `/etc/apt/keyrings/` keyring approach with `signed-by`, selected automatically when the major version is ≥ 26.
- **Supported OS list** (`WelcomeFooter.vue`): Added 26.04 to the allowed versions check so the welcome screen accepts Ubuntu 26.04 connections.
- **Test images** (91 files): Updated all integration tests and molecule test scenarios from `ubuntu-24.04`/`ubuntu:noble` to `ubuntu-26.04`/`ubuntu:resolute`.